### PR TITLE
Fix event handling of buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,13 @@
       <button popovertoggletarget="popover1">Click to toggle Popover 1</button>
       <button popovertoggletarget="popover2">Click to toggle Popover 2</button>
       <button popovershowtarget="popover3">Click to show Popover 3</button>
-      <button popovershowtarget="popover5">Click to show Popover 5</button>
+      <button popovershowtarget="popover5">
+        <span>Click to show Popover 5</span>
+      </button>
       <button popoverhidetarget="popover5">Click to hide Popover 5</button>
-      <button popovertoggletarget="popover9">Click to toggle Popover 9</button>
+      <button popovertoggletarget="popover9">
+        <span>Click to toggle Popover 9</span>
+      </button>
       <button popovertoggletarget="popover10">
         Click to toggle Popover 10
       </button>

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -68,15 +68,18 @@ export function apply() {
 
   document.addEventListener('click', (event: Event) => {
     const target = event.target;
-    if (!(target instanceof HTMLElement)) return;
+    if (!(target instanceof Element)) return;
     const doc = target.ownerDocument;
     let effectedPopover: HTMLElement | null = target.closest('[popover]');
-    const isButton = target instanceof HTMLButtonElement;
+    const button = target.closest(
+      '[popovertoggletarget],[popoverhidetarget],[popovershowtarget]',
+    );
+    const isButton = button instanceof HTMLButtonElement;
 
     // Handle Popover triggers
-    if (isButton && target.hasAttribute('popovershowtarget')) {
+    if (isButton && button.hasAttribute('popovershowtarget')) {
       effectedPopover = doc.getElementById(
-        target.getAttribute('popovershowtarget') || '',
+        button.getAttribute('popovershowtarget') || '',
       );
 
       if (
@@ -86,9 +89,9 @@ export function apply() {
       ) {
         effectedPopover.showPopover();
       }
-    } else if (isButton && target.hasAttribute('popoverhidetarget')) {
+    } else if (isButton && button.hasAttribute('popoverhidetarget')) {
       effectedPopover = doc.getElementById(
-        target.getAttribute('popoverhidetarget') || '',
+        button.getAttribute('popoverhidetarget') || '',
       );
 
       if (
@@ -98,9 +101,9 @@ export function apply() {
       ) {
         effectedPopover.hidePopover();
       }
-    } else if (isButton && target.hasAttribute('popovertoggletarget')) {
+    } else if (isButton && button.hasAttribute('popovertoggletarget')) {
       effectedPopover = doc.getElementById(
-        target.getAttribute('popovertoggletarget') || '',
+        button.getAttribute('popovertoggletarget') || '',
       );
 
       if (effectedPopover && effectedPopover.popover) {

--- a/tests/triggers.spec.ts
+++ b/tests/triggers.spec.ts
@@ -71,7 +71,7 @@ test('clicking button[popoverhidetarget=popover5] should do nothing as it is alr
   await expect(popover).toBeHidden();
 });
 
-test('clicking button[popovershowtarge=popover5] then button[popoverhidetarget=popover5] should show and hide popover', async ({
+test('clicking button[popovershowtarget=popover5] then button[popoverhidetarget=popover5] should show and hide popover', async ({
   page,
 }) => {
   const popover = (await page.locator('#popover5')).nth(0);


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&fix-event-handling-of-buttons)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description

`<button>` tags can have HTML inside of them. Currently the code for button handling checks to see if `event.target` is an appropriate button element, but this isn't accurate because the `event.target` will be the element that initiated the event, which could be the inner HTML of a button element.

In order to validate this, I've added some `<span>` elements inside the `<button>` tags, which fails the test suite as the buttons no longer function. In a separate commit I have corrected the event handler code to grab the closest applicable button element in the tree which has one of the `popoverXtarget` attributes.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._
If you checkout commit [de6566c](https://github.com/oddbird/popover-polyfill/pull/40/commits/de6566c28b9bcc719b76bc79e8cd670fa8dfaca6) you can validate that "Click to show Popover 5" and "Click to toggle Popover 9" won't work. Checking out HEAD of this branch will work.

