### PR TITLE
0.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oddbird/popover-polyfill",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oddbird/popover-polyfill",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@playwright/test": "^1.28.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oddbird/popover-polyfill",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Popover Attribute Polyfill",
   "license": "BSD-3-Clause",
   "publishConfig": {


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&004)

## Description

This PR bumps the version number.

The current code in `main` is out of date with the latest published version of this package, which includes fixes in #40: https://github.com/oddbird/popover-polyfill/compare/v0.0.3...main