### PR TITLE
docs: even also include CSS within the CDN section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ reasons](https://blog.wesleyac.com/posts/why-not-javascript-cdn) such as
 performance and robustness.
 
 ```html
+<link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@oddbird/popover-polyfill@latest/dist/popover.css"
+      crossorigin="anonymous"
+>
 <script
   src="https://cdn.jsdelivr.net/npm/@oddbird/popover-polyfill@latest"
   crossorigin="anonymous"


### PR DESCRIPTION
## Description
As it's mentioned in the [CDN section](https://github.com/oddbird/popover-polyfill/blob/main/README.md?plain=1#L58) this part would be for prototyping or testing, so we could mention the CSS in here directly as well, even though that it's separated in the previous sections that are meant for production use and have some further description regarding CSS usage.