### PR TITLE
use standard text and background colors

### DIFF
--- a/src/popover.css
+++ b/src/popover.css
@@ -11,6 +11,8 @@
   border: 1px solid;
   background: white;
   color: black;
+  background: canvas;
+  color: canvastext;
   overflow: auto;
   margin: auto;
   inset-inline-start: 0;
@@ -35,6 +37,8 @@
   [popover='manual' i] {
     background: black;
     color: white;
+    background: canvas;
+    color: canvastext;
   }
 }
 


### PR DESCRIPTION
The system colors are supported in every recent browser version: `canvastext` `canvas`

I don't know if we still need the fallbacks, or which browsers the polyfill supports. Otherwise we could do without the media-query.

![](https://source.unsplash.com/featured/?cute,animal&CHANGE_ME)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->


## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._


## Show me
_Provide screenshots/animated gifs/videos if necessary._


# REMEMBER: Attach this PR to the Trello card
