### PR TITLE
Fixup css

### DIFF
--- a/src/popover.css
+++ b/src/popover.css
@@ -1,6 +1,4 @@
-[popover='' i],
-[popover='auto' i],
-[popover='manual' i] {
+[popover] {
   display: none;
   position: fixed;
   inset: 0;
@@ -18,9 +16,7 @@
 }
 
 /* stylelint-disable selector-class-pattern */
-[popover='' i].\:open,
-[popover='auto' i].\:open,
-[popover='manual' i].\:open {
+[popover].\:open {
   display: block;
   position: fixed;
   z-index: 2147483647;

--- a/src/popover.css
+++ b/src/popover.css
@@ -5,10 +5,7 @@
   padding: 0.25em;
   width: fit-content;
   height: fit-content;
-  border-width: initial;
-  border-style: solid;
-  border-color: initial;
-  border-image: initial;
+  border: solid;
   background: canvas;
   color: canvastext;
   overflow: auto;

--- a/src/popover.css
+++ b/src/popover.css
@@ -1,5 +1,6 @@
 [popover] {
   position: fixed;
+  z-index: 2147483647;
   inset: 0;
   padding: 0.25em;
   width: fit-content;
@@ -14,21 +15,16 @@
   margin: auto;
 }
 
+/* stylelint-disable selector-class-pattern */
 [popover]:not(.\:open) {
   display: none;
 }
+/* stylelint-enable selector-class-pattern */
 
 [popover][anchor] {
   inset:auto;
   anchor-scroll: implicit;
 }
-
-/* stylelint-disable selector-class-pattern */
-[popover].\:open {
-  position: fixed;
-  z-index: 2147483647;
-}
-/* stylelint-enable selector-class-pattern */
 
 /* Necessary for compatibility with Chrome */
 [popover]:not(:-internal-popover-hidden) {

--- a/src/popover.css
+++ b/src/popover.css
@@ -15,6 +15,11 @@
   margin: auto;
 }
 
+[popover][anchor] {
+  inset:auto;
+  anchor-scroll: implicit;
+}
+
 /* stylelint-disable selector-class-pattern */
 [popover].\:open {
   display: block;

--- a/src/popover.css
+++ b/src/popover.css
@@ -3,20 +3,18 @@
 [popover='manual' i] {
   display: none;
   position: fixed;
-  top: 0;
-  left: 0;
-  padding: 1em;
+  inset: 0;
+  padding: 0.25em;
   width: fit-content;
   height: fit-content;
-  border: 1px solid;
+  border-width: initial;
+  border-style: solid;
+  border-color: initial;
+  border-image: initial;
   background: canvas;
   color: canvastext;
   overflow: auto;
   margin: auto;
-  inset-inline-start: 0;
-  inset-inline-end: 0;
-  inset-block-start: 0;
-  inset-block-end: 0;
 }
 
 /* stylelint-disable selector-class-pattern */

--- a/src/popover.css
+++ b/src/popover.css
@@ -19,8 +19,7 @@
 /* stylelint-enable selector-class-pattern */
 
 [popover][anchor] {
-  inset:auto;
-  anchor-scroll: implicit;
+  inset: auto;
 }
 
 /* Necessary for compatibility with Chrome */

--- a/src/popover.css
+++ b/src/popover.css
@@ -1,5 +1,4 @@
 [popover] {
-  display: none;
   position: fixed;
   inset: 0;
   padding: 0.25em;
@@ -15,6 +14,10 @@
   margin: auto;
 }
 
+[popover]:not(.\:open) {
+  display: none;
+}
+
 [popover][anchor] {
   inset:auto;
   anchor-scroll: implicit;
@@ -22,7 +25,6 @@
 
 /* stylelint-disable selector-class-pattern */
 [popover].\:open {
-  display: block;
   position: fixed;
   z-index: 2147483647;
 }

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -44,7 +44,6 @@ test('popover as "manual"', async ({ page }) => {
 
 test('popover as "invalid"', async ({ page }) => {
   const popover = (await page.locator('#popover6')).nth(0);
-  await expect(popover).toBeVisible();
   await expect(
     async () => await popover.evaluate((node) => node.showPopover()),
   ).rejects.toThrow(


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&CSSFIXES)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

## Description

This changes up some of the CSS to align closer to [Chrome's user-agent CSS](https://github.com/chromium/chromium/blob/main/third_party/blink/renderer/core/css/popover.css). What's changed:

 - Simplify selectors to just `[popover]` as Chrome does.
 - Remove `top`, `left` in favour of `inset`.
 - Drop the `inset-*-*` properties.
 - Shrink padding from `1em` to `0.25em`.
 - Drop the 1px default border. Chrome's border-width is `initial`.
 - Move the z-index into the `[popover]` selector so it's always applied
 - Rather than `[popover]` having `display: none`, and `[popver]:open` being `display: block`, we now have `[popover]:not(:open)` as `display: none`. This way one can style a popover element to be something like `display: grid` or `display: flex` and popover will not override that.
 - Add `[popover][anchor]` styles, to avoid conflicting with anchored positioning.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._


## Show me
_Provide screenshots/animated gifs/videos if necessary._


# REMEMBER: Attach this PR to the Trello card
