### PR TITLE
fix(src): remove stop propagation to allow handlers

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -98,11 +98,11 @@ export function apply() {
 
   const onClick = (event: Event) => {
     const target = event.target;
-    if (!(target instanceof Element)) return;
+    if (!(target instanceof Element) || target?.shadowRoot) return;
     const root = target.getRootNode();
-    if (root instanceof ShadowRoot) {
-      event.stopPropagation();
-    } else if (!(root instanceof Document)) return;
+    if (!(root instanceof ShadowRoot) && !(root instanceof Document)) {
+      return;
+    }
     let effectedPopover = closestElement(
       '[popover]',
       target,


### PR DESCRIPTION
stopPropagation prevents handlers in authors environment from running,
the only reason to run it, to begin with, was to prevent click from
being fired both in document and shadow roots at the same time