### PR TITLE
Update popover.css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Popover Attribute Polyfill Changelog
 
-## UNRELEASED
+## 0.0.7: 2023-01-19
 
+- 🐛 BUGFIX: Fix display issue with native popups --
+  [#64](https://github.com/oddbird/popover-polyfill/pull/64)
 - 🐛 BUGFIX: Remove `stopPropagation` to allow handlers --
   [#63](https://github.com/oddbird/popover-polyfill/pull/63)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oddbird/popover-polyfill",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oddbird/popover-polyfill",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@playwright/test": "^1.29.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oddbird/popover-polyfill",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Popover Attribute Polyfill",
   "license": "BSD-3-Clause",
   "publishConfig": {

--- a/src/popover.css
+++ b/src/popover.css
@@ -13,16 +13,13 @@
 }
 
 /* stylelint-disable selector-class-pattern */
-[popover]:not(.\:open) {
-  display: none;
+@supports not selector([popover]:open) {
+  [popover]:not(.\:open) {
+    display: none;
+  }
 }
 /* stylelint-enable selector-class-pattern */
 
 [popover][anchor] {
   inset: auto;
-}
-
-/* Necessary for compatibility with Chrome */
-[popover]:not(:-internal-popover-hidden) {
-  display: block;
 }


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&fix-native)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

## Description

This fixes a slight issue with native popups, which remain `display: none` because `[popup]:not(.\:open)` is always true for those popups.

~~To fix this issue this adds `[popup]:not(.\:open, :open)` . In other words apply this style only if the element has neither the `.\:open` class nor the `:open` psuedo selector.~~ (This didn't work!)

To fix this issue this wraps the `[popup]:not(.\:open)` selector in a `@supports not selector([popover]:open)` . In other words apply this style only if the element isn't a native popover.

I've tested the example page in both Chrome and Firefox, and Chrome with Experimental Web Platform features enabled.

## Steps to test/reproduce
Try running the demo in Chrome with Experimental Web Technology enabled. 


## Show me
_Provide screenshots/animated gifs/videos if necessary._

![image](https://user-images.githubusercontent.com/118266/213484431-46516ecb-f852-4d19-9e6e-d5fbd0a1ed4c.png)



# REMEMBER: Attach this PR to the Trello card
