### PR TITLE
add beforetoggle events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oddbird/popover-polyfill",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oddbird/popover-polyfill",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@playwright/test": "^1.29.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oddbird/popover-polyfill",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Popover Attribute Polyfill",
   "license": "BSD-3-Clause",
   "publishConfig": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,17 @@
 import { apply, isSupported } from './popover.js';
 
 declare global {
+  interface BeforeToggleEvent extends Event {
+    currentState: string;
+    newState: string;
+  }
   interface HTMLElement {
     popover: 'auto' | 'manual' | null;
     showPopover(): void;
     hidePopover(): void;
+  }
+  interface Window {
+    BeforeToggleEvent: BeforeToggleEvent;
   }
 }
 

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -13,7 +13,9 @@ expect.extend({
     await expect(popover).toBeVisible();
     await expect(
       async () => await popover.evaluate((node) => node.showPopover()),
-    ).rejects.toThrow('DOMException: Invalid on already-showing');
+    ).rejects.toThrow(
+      'DOMException: Cannot show or hide popover on invalid or already visible element',
+    );
     await expect(
       await popover.evaluate((node) => node.hidePopover()),
     ).toBeUndefined();
@@ -47,6 +49,6 @@ test('popover as "invalid"', async ({ page }) => {
   await expect(
     async () => await popover.evaluate((node) => node.showPopover()),
   ).rejects.toThrow(
-    'DOMException: Not supported on element that does not have valid popover attribute',
+    'DOMException: Cannot show or hide popover on invalid or already visible element',
   );
 });

--- a/tests/events.spec.ts
+++ b/tests/events.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test('popover emits beforetoggle before showing', async ({ page }) => {
+  const popover7 = (await page.locator('#popover7')).nth(0);
+  await expect(
+    await popover7.evaluate((node) => {
+      let states = [];
+      node.addEventListener('beforetoggle', (e) => {
+        states = [e.currentState, e.newState];
+      });
+      node.showPopover();
+      return states;
+    }),
+  ).toStrictEqual(['closed', 'open']);
+  await expect(popover7).toBeVisible();
+});
+
+test('popover showPopover can be prevented by cancelling beforetoggle', async ({
+  page,
+}) => {
+  const popover7 = (await page.locator('#popover7')).nth(0);
+  await expect(
+    await popover7.evaluate((node) => {
+      let states = [];
+      node.addEventListener('beforetoggle', (e) => {
+        states = [e.currentState, e.newState];
+        e.preventDefault();
+      });
+      node.showPopover();
+      return states;
+    }),
+  ).toStrictEqual(['closed', 'open']);
+  await expect(popover7).toBeHidden();
+});
+
+test('popover emits beforetoggle before closing', async ({ page }) => {
+  const popover7 = (await page.locator('#popover7')).nth(0);
+  await expect(
+    await popover7.evaluate((node) => node.showPopover()),
+  ).toBeUndefined();
+  await expect(popover7).toBeVisible();
+  await expect(
+    await popover7.evaluate((node) => {
+      let states = [];
+      node.addEventListener('beforetoggle', (e) => {
+        states = [e.currentState, e.newState];
+      });
+      node.hidePopover();
+      return states;
+    }),
+  ).toStrictEqual(['open', 'closed']);
+  await expect(popover7).toBeHidden();
+});
+
+test('popover hidePopover cannot be prevented by cancelling beforetoggle', async ({
+  page,
+}) => {
+  const popover7 = (await page.locator('#popover7')).nth(0);
+  await expect(
+    await popover7.evaluate((node) => node.showPopover()),
+  ).toBeUndefined();
+  await expect(popover7).toBeVisible();
+  await expect(
+    await popover7.evaluate((node) => {
+      let states = [];
+      node.addEventListener('beforetoggle', (e) => {
+        states = [e.currentState, e.newState];
+        e.preventDefault();
+      });
+      node.hidePopover();
+      return states;
+    }),
+  ).toStrictEqual(['open', 'closed']);
+  await expect(popover7).toBeHidden();
+});


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&beforetoggleevents)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description

This PR adds the `beforetoggle` event which is defined by the spec: https://whatpr.org/html/8221/popover.html#show-popover. It also exposes the global `BeforeToggleEvent` which is a new `Event` subclass that is exposed on `window`.

The `beforetoggle` event has two properties: `currentState` and `newState`. They are set to `'open'` or `'closed'` based on the current and desired state of the popover. The `beforetoggle` event when _showing_ a popover is cancelable. The event when hiding a popover is _not_ cancelable. This event does not bubble.

## Steps to test/reproduce

I've added tests for each of these conditions. Check out `events.spec.ts`

# REMEMBER: Attach this PR to the Trello card
