### PR TITLE
alter aria-expanded attributes for popover invokers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## UNRELEASED
 
 - 🏠 INTERNAL: Upgrade dependencies
+- 🚀 NEW: Add support for `aria-expanded` on invokers --
+  [#77](https://github.com/oddbird/popover-polyfill/pull/77)
 
 ## 0.0.9: 2023-02-03
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,39 @@ performance and robustness.
 After installation the polyfill will automatically add the correct methods and
 attributes to the HTMLElement class.
 
+## Caveats
+
+This polyfill is not a perfect replacement for the native behavior, there are
+some caveats which will need accommodations:
+
+- Native `popover` has an `:open` and `:closed` pseudo selector state. This is
+  not possible to polyfill, so instead this adds the `.\:open` CSS class to any
+  open popover.
+
+  - `:closed` is not implemented due to difficulty in finding popover elements
+    during page load. As such, you'll need to style them using `:not(.\:open)`.
+
+  - Using native `:open` in CSS that does not support native `popover` results
+    in an invalid selector, and so the entire declaration is thrown away. This
+    is important because if you intend to style a popover using `.\:open` it
+    will need to be a separate declaration. e.g.
+    `[popover]:open, [popover].\:open` will not work.
+
+- Native `popover` elements use the `:top-layer` pseudo element which gets
+  placed above all other elements on the page, regardless of overflow or
+  z-index. This is not possible to polyfill, and so this library simply sets a
+  really high `z-index`. This means if a popover is within an element that has
+  `overflow:` or `position:` CSS, then there will be visual differences between
+  the polyfill and the native behavior.
+
+- Native _invokers_ (that is: buttons or inputs using the `popoverHideTarget`,
+  `popoverShowTarget`, or `popoverToggleTarget` attributes) on `popover=auto`
+  will render in the accessibility tree as elements with `expanded`. The only
+  way to do this in the polyfill is setting the `aria-expanded` attribute on
+  those elements. This _may_ impact mutation observers or frameworks which do
+  DOM diffing, or it may interfere with other code which sets `aria-expanded` on
+  elements.
+
 ## Contributing
 
 Visit our [contribution guidelines](https://github.com/oddbird/popover-polyfill/blob/main/CONTRIBUTING.md).

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
       <button popovertoggletarget="popover9">
         <span>Click to toggle Popover 9</span>
       </button>
-      <button popovertoggletarget="popover10" aria-expanded="false">
+      <button popovertoggletarget="popover10">
         Click to toggle Popover 10
       </button>
       <button popovertoggletarget="notExist">Click to toggle nothing</button>

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
       <button popovertoggletarget="popover9">
         <span>Click to toggle Popover 9</span>
       </button>
-      <button popovertoggletarget="popover10">
+      <button popovertoggletarget="popover10" aria-expanded="false">
         Click to toggle Popover 10
       </button>
       <button popovertoggletarget="notExist">Click to toggle nothing</button>

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,0 +1,22 @@
+export const popovers = new Set<HTMLElement>();
+export const invokers = new Set<HTMLButtonElement | HTMLInputElement>();
+
+export const popoverInvokerSupportedElements = [
+  'button',
+  'input[type="button"]',
+  'input[type="submit"]',
+  'input[type="image"]',
+  'input[type="reset"]',
+] as const;
+
+export const popoverInvokerAttributes = [
+  'popoverToggleTarget',
+  'popoverShowTarget',
+  'popoverHideTarget',
+] as const;
+
+export const popoverInvokerSelector = popoverInvokerSupportedElements
+  .flatMap((s) => {
+    return popoverInvokerAttributes.map((a) => `${s}[${a}]`);
+  })
+  .join(', ');

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,9 +1,4 @@
-import {
-  invokers,
-  popoverInvokerAttributes,
-  popoverInvokerSelector,
-  popovers,
-} from './data.js';
+import { invokers, popoverInvokerAttributes, popovers } from './data.js';
 import {
   getInvokersFromNode,
   getPopoversFromNode,

--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -1,0 +1,86 @@
+import { invokers, popoverInvokerSelector, popovers } from './data.js';
+export const initialAriaExpandedValue = new WeakMap<
+  HTMLButtonElement | HTMLInputElement,
+  null | string
+>();
+
+export function* getInvokersFor(el: HTMLElement) {
+  if (!popovers.has(el)) return;
+  for (const invoker of invokers) {
+    if (getPopoverFor(invoker) === el) yield invoker;
+  }
+}
+
+export function getPopoverFor(el: HTMLButtonElement | HTMLInputElement) {
+  return (
+    el.popoverToggleTargetElement ||
+    el.popoverShowTargetElement ||
+    el.popoverHideTargetElement
+  );
+}
+
+export function setInvokerAriaExpanded(
+  el: HTMLButtonElement | HTMLInputElement,
+) {
+  if (!initialAriaExpandedValue.has(el)) {
+    initialAriaExpandedValue.set(el, el.getAttribute('aria-expanded'));
+  }
+  const popover = getPopoverFor(el);
+  if (popover) {
+    invokers.add(el);
+  } else {
+    invokers.delete(el);
+  }
+  if (popover && popover.popover === 'auto') {
+    el.setAttribute(
+      'aria-expanded',
+      String(popover.classList.contains(':open')),
+    );
+  } else {
+    const initialValue = initialAriaExpandedValue.get(el);
+    if (!initialValue) {
+      el.removeAttribute('aria-expanded');
+    } else {
+      el.setAttribute('aria-expanded', initialValue);
+    }
+  }
+}
+
+export function* getPopoversFromNode(node: Node) {
+  if (node instanceof HTMLElement && node.hasAttribute('popover')) {
+    yield node;
+  }
+  if (
+    node instanceof Document ||
+    node instanceof ShadowRoot ||
+    node instanceof HTMLElement
+  ) {
+    for (const el of node.querySelectorAll('[popover]')) {
+      if (el instanceof HTMLElement) {
+        yield el;
+      }
+    }
+  }
+}
+
+export function* getInvokersFromNode(
+  node: Node,
+): Generator<HTMLButtonElement | HTMLInputElement> {
+  if (
+    (node instanceof HTMLInputElement || node instanceof HTMLButtonElement) &&
+    node.matches(popoverInvokerSelector)
+  ) {
+    yield node;
+  }
+  if (
+    node instanceof Document ||
+    node instanceof ShadowRoot ||
+    node instanceof HTMLElement
+  ) {
+    for (const el of node.querySelectorAll(popoverInvokerSelector)) {
+      if (el instanceof HTMLInputElement || el instanceof HTMLButtonElement) {
+        yield el;
+      }
+    }
+  }
+}

--- a/tests/triggers.spec.ts
+++ b/tests/triggers.spec.ts
@@ -8,18 +8,12 @@ test('clicking button[popovertoggletarget=popover10] should hide open popover', 
   page,
 }) => {
   const popover = (await page.locator('#popover10')).nth(0);
-  const button = (
-    await page.locator('button[popovertoggletarget=popover10]')
-  ).nth(0);
   await expect(popover).toBeHidden();
-  await expect(button).toHaveAttribute('aria-expanded', 'false');
   await expect(
     await popover.evaluate((node) => node.showPopover()),
   ).toBeUndefined();
-  await expect(button).toHaveAttribute('aria-expanded', 'true');
   await expect(popover).toBeVisible();
-  await button.click();
-  await expect(button).toHaveAttribute('aria-expanded', 'false');
+  await page.click('button[popovertoggletarget=popover10]');
   await expect(popover).toBeHidden();
 });
 
@@ -42,6 +36,23 @@ test('clicking button[popovertoggletarget=popover1] should show then hide open p
   await expect(popover).toBeVisible();
   await page.click('button[popovertoggletarget=popover1]');
   await expect(popover).toBeHidden();
+});
+
+test('clicking button[popovertoggletarget=popover1] should set button aria-expanded attribute appropriately', async ({
+  page,
+}) => {
+  const popover = (await page.locator('#popover1')).nth(0);
+  const button = (
+    await page.locator('button[popovertoggletarget="popover1"]')
+  ).nth(0);
+  await expect(popover).toBeHidden();
+  await expect(button).toHaveAttribute('aria-expanded', 'false');
+  await button.click();
+  await expect(popover).toBeVisible();
+  await expect(button).toHaveAttribute('aria-expanded', 'true');
+  await button.click();
+  await expect(popover).toBeHidden();
+  await expect(button).toHaveAttribute('aria-expanded', 'false');
 });
 
 test('clicking button[popovershowtarget=popover3] should show open popover', async ({

--- a/tests/triggers.spec.ts
+++ b/tests/triggers.spec.ts
@@ -8,12 +8,18 @@ test('clicking button[popovertoggletarget=popover10] should hide open popover', 
   page,
 }) => {
   const popover = (await page.locator('#popover10')).nth(0);
+  const button = (
+    await page.locator('button[popovertoggletarget=popover10]')
+  ).nth(0);
   await expect(popover).toBeHidden();
+  await expect(button).toHaveAttribute('aria-expanded', 'false');
   await expect(
     await popover.evaluate((node) => node.showPopover()),
   ).toBeUndefined();
+  await expect(button).toHaveAttribute('aria-expanded', 'true');
   await expect(popover).toBeVisible();
-  await page.click('button[popovertoggletarget=popover10]');
+  await button.click();
+  await expect(button).toHaveAttribute('aria-expanded', 'false');
   await expect(popover).toBeHidden();
 });
 


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&aria-expanded)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->

Native popover in Chrome exposes "expanded" accessibility info for popover invokers, which allows assistive technologies to know that the button will expand some kind of dialog or menu.

This PR adds `aria-expanded=false` on all popover invoker buttons that target an `auto` popover, during page load or insertion into the DOM, and when a popover becomes visible, it will toggle `aria-expanded=true` for all invokers of a visible popover.