### PR TITLE
Add escape to dismiss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- 🚀 NEW: Add support for Escape to dismiss auto popovers --
+  [#82](https://github.com/oddbird/popover-polyfill/pull/82)
 - 🚀 NEW: Showing an `auto` popover closes other `auto` popovers --
   [#83](https://github.com/oddbird/popover-polyfill/pull/83)
 - 🚀 NEW: Add support for focus restoration on popover close --

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -265,8 +265,16 @@ export function apply() {
     );
   };
 
+  const onKeydown = (event: Event) => {
+    const key = (event as KeyboardEvent).key;
+    if (key === 'Escape' || key === 'Esc') {
+      hideOpenAutoPopovers();
+    }
+  };
+
   const addOnClickEventListener = (root: Document | ShadowRoot) => {
     root.addEventListener('click', onClick);
+    root.addEventListener('keydown', onKeydown);
   };
 
   observePopoversMutations(document);

--- a/tests/dismiss.spec.ts
+++ b/tests/dismiss.spec.ts
@@ -81,3 +81,30 @@ test('showing an auto popover should close all other auto popovers', async ({
   await expect(popover7).toBeVisible();
   await expect(popover3).toBeHidden();
 });
+
+test('pressing Escape dismisses auto popovers', async ({ page }) => {
+  const popover7 = (await page.locator('#popover7')).nth(0);
+  await expect(
+    await popover7.evaluate((node) => node.showPopover()),
+  ).toBeUndefined();
+  await expect(popover7).toBeVisible();
+
+  await page.keyboard.press('Escape');
+
+  await expect(popover7).toBeHidden();
+});
+
+test('pressing Escape focused in popover dismisses auto popovers', async ({
+  page,
+}) => {
+  const popover3 = (await page.locator('#popover3')).nth(0);
+  await expect(
+    await popover3.evaluate((node) => node.showPopover()),
+  ).toBeUndefined();
+  await expect(popover3).toBeVisible();
+  await page.locator('#popover3 a[href]').focus();
+
+  await page.keyboard.press('Escape');
+
+  await expect(popover3).toBeHidden();
+});


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&escapetoclose)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->
This PR adds support for the `Escape` key causing all auto popovers to be dismissed.


## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._
- Enact the `Click to show Popover 3` button
- Observe popover 3 is open
- Press Escape
- Observe popover 3 is now closed.

## Show me
_Provide screenshots/animated gifs/videos if necessary._


# REMEMBER: Attach this PR to the Trello card
