### PR TITLE
Showing an `auto` popover hides all other `auto` popovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- 🚀 NEW: Showing an `auto` popover closed other `auto` popovers --
+  [#83](https://github.com/oddbird/popover-polyfill/pull/83)
 - 🚀 NEW: Add support for focus restoration on popover close --
   [#81](https://github.com/oddbird/popover-polyfill/pull/81)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- 🚀 NEW: Showing an `auto` popover closed other `auto` popovers --
+- 🚀 NEW: Showing an `auto` popover closes other `auto` popovers --
   [#83](https://github.com/oddbird/popover-polyfill/pull/83)
 - 🚀 NEW: Add support for focus restoration on popover close --
   [#81](https://github.com/oddbird/popover-polyfill/pull/81)

--- a/src/data.ts
+++ b/src/data.ts
@@ -20,3 +20,6 @@ export const popoverInvokerSelector = popoverInvokerSupportedElements
     return popoverInvokerAttributes.map((a) => `${s}[${a}]`);
   })
   .join(', ');
+
+export const openPopoverSelector =
+  '[popover="" i].\\:open, [popover=auto i].\\:open';

--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -55,21 +55,6 @@ export function closestShadowPenetrating(
   return closestShadowPenetrating(selector, root.host);
 }
 
-export function hasPopoverAncestor(
-  element: Element,
-  popover: Element,
-): boolean {
-  let parent = element;
-  do {
-    const ancestor = closestShadowPenetrating('[popover]', parent);
-    if (!ancestor) return false;
-    if (ancestor === popover) return true;
-    parent =
-      ancestor.parentElement || (ancestor.getRootNode() as ShadowRoot)?.host;
-  } while (parent);
-  return false;
-}
-
 export function setInvokerAriaExpanded(
   el: HTMLButtonElement | HTMLInputElement,
 ) {

--- a/tests/dismiss.spec.ts
+++ b/tests/dismiss.spec.ts
@@ -64,3 +64,20 @@ test('click inside auto popover does not dismiss itself', async ({ page }) => {
   await popover7.evaluate((node) => node.click());
   await expect(popover7).toBeVisible();
 });
+
+test('showing an auto popover should close all other auto popovers', async ({
+  page,
+}) => {
+  const popover3 = (await page.locator('#popover3')).nth(0);
+  const popover7 = (await page.locator('#popover7')).nth(0);
+  await expect(
+    await popover3.evaluate((node) => node.showPopover()),
+  ).toBeUndefined();
+  await expect(popover3).toBeVisible();
+  await expect(popover7).toBeHidden();
+  await expect(
+    await popover7.evaluate((node) => node.showPopover()),
+  ).toBeUndefined();
+  await expect(popover7).toBeVisible();
+  await expect(popover3).toBeHidden();
+});


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&autohidesothers)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->
Working through various conditions, I discovered a bug in the existing behaviour. Calling `showPopover()` on an `auto` popover should hide all other `auto` popovers - there should only be one `auto` popover visible at a time.

I think this is related to #70 but I don't think #70 caused it.

This refactors a large part of the code to abstract the notion of hiding all auto popovers into a single function - and consequently the click handler gets heavily refactored. I've added a test to confirm that showing a auto popover hides others and done a fair amount of manual exploratory testing and I haven't seen this introduce any further regressions.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._
The tests should explain steps to reproduce.

## Show me
_Provide screenshots/animated gifs/videos if necessary._


# REMEMBER: Attach this PR to the Trello card
