### PR TITLE
Patch qsa matches closest to accept `:popover-open`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Popover Attribute Polyfill Changelog
 
+## 0.2.0: 2023-03-24
+
+- 🚀 NEW: Support for `:popover-open` psuedo selector
+  [#84](https://github.com/oddbird/popover-polyfill/pull/84)
+
 ## 0.1.1: 2023-03-24
 
 - 🐛 BUGFIX: Fix regression when targets have nested elements --

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Popover Attribute Polyfill Changelog
 
-## 0.2.0: 2023-03-24
+## Unreleased
 
-- 🚀 NEW: Support for `:popover-open` psuedo selector
+- 🚀 NEW: Support for `:popover-open` pseudo selector, including a polyfill for
+  JavaScript API methods (`querySelector`, `querySelectorAll`, `matches`, and
+  `closest`) --
   [#84](https://github.com/oddbird/popover-polyfill/pull/84)
 
 ## 0.1.1: 2023-03-24
@@ -47,7 +49,8 @@
 
 ## 0.0.8: 2023-01-26
 
-- 🚀 NEW: Add support for new [`beforetoggle` event](https://whatpr.org/html/8221/popover.html#show-popover) --
+- 🚀 NEW: Add support for new [`beforetoggle`
+  event](https://whatpr.org/html/8221/popover.html#show-popover) --
   [#68](https://github.com/oddbird/popover-polyfill/pull/68)
 - 🏠 INTERNAL: Upgrade dependencies
 
@@ -61,8 +64,9 @@
 
 ## 0.0.6: 2023-01-17
 
-- 🚀 NEW: Update CSS to align closer to [Chrome's user-agent CSS](https://github.com/chromium/chromium/blob/main/third_party/blink/renderer/core/css/popover.css) --
-  [#60](https://github.com/oddbird/popover-polyfill/pull/60)
+- 🚀 NEW: Update CSS to align closer to [Chrome's user-agent
+  CSS](https://github.com/chromium/chromium/blob/main/third_party/blink/renderer/core/css/popover.css)
+  -- [#60](https://github.com/oddbird/popover-polyfill/pull/60)
 - 🏠 INTERNAL: Upgrade dependencies
 
 ## 0.0.5: 2023-01-14

--- a/README.md
+++ b/README.md
@@ -93,18 +93,24 @@ attributes to the HTMLElement class.
 This polyfill is not a perfect replacement for the native behavior; there are
 some caveats which will need accommodations:
 
-- Native `popover` has an `:open` and `:closed` pseudo selector state. This is
-  not possible to polyfill, so instead this adds the `.\:open` CSS class to any
-  open popover.
+- A native `popover` has a `:popover-open` pseudo selector when in the open
+  state. Pseudo selectors cannot be polyfilled within CSS, and so instead the
+  polyfill will add the `.\:popover-open` CSS class to any open popover. In
+  other words a popover in the open state will have `class=":popover-open"`. In
+  CSS the `:` character must be escaped with a backslash.
 
-  - `:closed` is not implemented due to difficulty in finding popover elements
-    during page load. As such, you'll need to style them using `:not(.\:open)`.
+  - The `:popover-open` selector within JavaScript methods has been polyfilled,
+    so both `.querySelector(':popover-open')` _and_
+    `.querySelector('.\:popover-open')` will work to select the same element.
+    `matches` and `closest` have also been patched, so
+    `.matches(':popover-open')` will work the same as
+    `.matches('.\:popover-open')`.
 
-  - Using native `:open` in CSS that does not support native `popover` results
-    in an invalid selector, and so the entire declaration is thrown away. This
-    is important because if you intend to style a popover using `.\:open` it
-    will need to be a separate declaration. For example,
-    `[popover]:open, [popover].\:open` will not work.
+  - Using native `:popover-open` in CSS that does not support native `popover`
+    results in an invalid selector, and so the entire declaration is thrown
+    away. This is important because if you intend to style a popover using
+    `.\:popover-open` it will need to be a separate declaration. For example,
+    `[popover]:popover-open, [popover].\:popover-open` will not work.
 
 - Native `popover` elements use the `:top-layer` pseudo element which gets
   placed above all other elements on the page, regardless of overflow or

--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -235,7 +235,7 @@ export function showPopover(element: HTMLElement) {
   }
   previouslyFocusedElements.delete(element);
   const originallyFocusedElement = document.activeElement as HTMLElement;
-  element.classList.add(':open');
+  element.classList.add(':popover-open');
   visibilityState.set(element, 'showing');
   if (!topLayerElements.has(document)) {
     topLayerElements.set(document, new Set());
@@ -293,7 +293,7 @@ export function hidePopover(
   }
   topLayerElements.get(document)?.delete(element);
   autoPopoverList.get(document)?.delete(element);
-  element.classList.remove(':open');
+  element.classList.remove(':popover-open');
   visibilityState.set(element, 'hidden');
   if (fireEvents) {
     queuePopoverToggleEventTask(element, 'open', 'closed');

--- a/src/popover.css
+++ b/src/popover.css
@@ -13,6 +13,9 @@
 }
 
 /* stylelint-disable selector-class-pattern */
+
+/* This older `:open` pseudo selector is deprecated and support will be removed
+in a later release. */
 @supports not selector([popover]:open) {
   [popover]:not(.\:popover-open, dialog[open]) {
     display: none;

--- a/src/popover.css
+++ b/src/popover.css
@@ -14,12 +14,22 @@
 
 /* stylelint-disable selector-class-pattern */
 @supports not selector([popover]:open) {
-  [popover]:not(.\:open) {
+  [popover]:not(.\:popover-open, dialog[open]) {
     display: none;
+  }
+
+  [anchor].\:popover-open {
+    inset: auto;
+  }
+}
+
+@supports not selector([popover]:popover-open) {
+  [popover]:not(.\:popover-open, dialog[open]) {
+    display: none;
+  }
+
+  [anchor].\:popover-open {
+    inset: auto;
   }
 }
 /* stylelint-enable selector-class-pattern */
-
-[popover][anchor] {
-  inset: auto;
-}

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -12,9 +12,44 @@ expect.extend({
     ).toBeUndefined();
     await expect(popover).toBeVisible();
     await expect(
+      await popover.evaluate((node) => node.matches(':popover-open')),
+    ).toEqual(true);
+    await expect(
+      await popover.evaluate((node) => node.closest(':popover-open') === node),
+    ).toEqual(true);
+    await expect(
+      await popover.evaluate((node) => node.matches(':not(:popover-open)')),
+    ).toEqual(false);
+    await expect(
+      await popover.evaluate(
+        () => document.querySelectorAll(':popover-open').length,
+      ),
+    ).toEqual(1);
+    await expect(
       await popover.evaluate((node) => node.hidePopover()),
     ).toBeUndefined();
     await expect(popover).toBeHidden();
+    await expect(
+      await popover.evaluate((node) => node.matches(':popover-open')),
+    ).toEqual(false);
+    await expect(
+      await popover.evaluate((node) => node.matches(':not(:popover-open)')),
+    ).toEqual(true);
+    await expect(
+      await popover.evaluate(
+        (node) => node.closest(':not(:popover-open)') === node,
+      ),
+    ).toEqual(true);
+    await expect(
+      await popover.evaluate(
+        () => document.querySelectorAll(':popover-open').length,
+      ),
+    ).toEqual(0);
+    await expect(
+      await popover.evaluate(
+        () => document.querySelectorAll('[popover]:popover-open').length,
+      ),
+    ).toEqual(0);
     return { pass: true };
   },
 });


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&patchcssselectorfns)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->
A potentially controversial change.

By default running something like `el.matches(':open')` on a browser without native Popover will result in an exception:

Chrome:
```
DOMException: Failed to execute 'matches' on 'Element': ':open' is not a valid selector.
```

Firefox:
```
DOMException: Element.matches: ':open' is not a valid selector
```

This means users of this polyfill need to work around this; either by using a `try`/`catch`, or by doing feature detection up front, e.g.:

```js
let openSelector = ':open'
try {
  document.querySelector(openSelector)
} catch {
  // use polyfilled selector instead
  openSelector = '.\\:open'
}
```

This is a little cumbersome and has to be done for every selector you intend to use, and given we're patching prototype methods anyway, perhaps it could be useful for us to patch the CSS selector functions (I believe I have them all, `querySelector`, `querySelectorAll`, `matches`, `closest`).

This change patches all of those functions taking the selector string given and replacing instances of `:open` with `.\\:open` and `:closed` with `:not(.\\:open)`. This allows us to use the `:open`/`:closed` selector and have it work with the polyfill.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._

Tests have been added to ensure qsa/matches/closed work but it doesn't do anything close to exhaustive input testing. I've manually tested the replacer function with various inputs. We could add some unit tests to ensure its robustness, but here's how I validated it:

```js
const nonEscapedOpenSelector = /(^|[^\\]):open\b/g;
const nonEscapedClosedSelector = /(^|[^\\]):closed\b/g;
  function rewriteSelector(selector) {
    return selector
      .replace(nonEscapedOpenSelector, '$1.\\:open')
      .replace(nonEscapedClosedSelector, '$1:not(.\\:open)');
  }
console.assert(rewriteSelector(':open') == '.\\:open')
console.assert(rewriteSelector('.\\:open') == '.\\:open')
console.assert(rewriteSelector('[bar]:open') == '[bar].\\:open')
console.assert(rewriteSelector('[bar]:opened') == '[bar]:opened')
console.assert(rewriteSelector('[bar]:open.\\:open:open') == '[bar].\\:open.\\:open.\\:open')
console.assert(rewriteSelector(':closed') == ':not(.\\:open)')
console.assert(rewriteSelector('.\\:closed') == '.\\:closed')
```

## Show me
_Provide screenshots/animated gifs/videos if necessary._


# REMEMBER: Attach this PR to the Trello card
