### PR TITLE
rewrite nearestInclusive.* algos to be closer to the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Popover Attribute Polyfill
 
-[Explainer](https://open-ui.org/components/popover.research.explainer)
+[![Build Status](https://github.com/oddbird/popover-polyfill/actions/workflows/test.yml/badge.svg)](https://github.com/oddbird/popover-polyfill/actions/workflows/test.yml) [![npm version](https://badge.fury.io/js/@oddbird%2Fpopover-polyfill.svg)](https://badge.fury.io/js/@oddbird%2Fpopover-polyfill) [![Netlify Status](https://api.netlify.com/api/v1/badges/35bc7ba7-97a2-4e41-93ed-5141988adb1e/deploy-status)](https://app.netlify.com/sites/popover-polyfill/deploys)
 
-This polyfills the HTML `popover` attribute and `showPopover`/`hidePopover`/`togglePopover` methods onto HTMLElement, as well as the `popovertarget` and `popovertargetaction` attributes on Button elements.
+- [Demo](https://popover-polyfill.netlify.app/)
+- [Explainer](https://open-ui.org/components/popover.research.explainer/)
+
+This polyfills the HTML `popover` attribute and
+`showPopover`/`hidePopover`/`togglePopover` methods onto HTMLElement, as well as
+the `popovertarget` and `popovertargetaction` attributes on Button elements.
 
 ## Polyfill Installation
 

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 
     <div id="buttons">
       <button popovertarget="popover1" aria-expanded="false">
-        Click to toggle Popover 1
+        <span>Click to toggle Popover 1</span>
       </button>
       <button popovertarget="popover2">Click to toggle Popover 2</button>
       <button popovertargetaction="show" popovertarget="popover3">

--- a/index.html
+++ b/index.html
@@ -50,7 +50,6 @@
       <div id="host"></div>
 
       <script type="module">
-        import sheet from './dist/popover.css' assert { type: 'css' };
         const host = document.getElementById('host');
         const shadowRoot = host.attachShadow({ mode: 'open' });
         shadowRoot.innerHTML = `<button popovertarget="shadowedPopover">
@@ -63,7 +62,10 @@
                 <div>
                   <div id="shadowedNestedPopover" popover="auto">Shadowed Nested Popover (auto)</div>
                 </div>`;
-        shadowRoot.adoptedStyleSheets = [sheet];
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = './dist/popover.css';
+        shadowRoot.prepend(link);
         document.getElementById('crossTreeToggle').popoverTargetElement =
           shadowRoot.getElementById('shadowedPopover');
       </script>

--- a/tests/triggers.spec.ts
+++ b/tests/triggers.spec.ts
@@ -36,6 +36,21 @@ test('clicking button[popovertarget=popover1] should show then hide open popover
   await expect(popover).toBeVisible();
   await page.click('button[popovertarget=popover1]');
   await expect(popover).toBeHidden();
+  await page.click('button[popovertarget=popover1]');
+  await expect(popover).toBeVisible();
+});
+
+test('clicking element inside button[popovertarget=popover1] should show then hide open popover', async ({
+  page,
+}) => {
+  const popover = (await page.locator('#popover1')).nth(0);
+  await expect(popover).toBeHidden();
+  await page.click('button[popovertarget=popover1] span');
+  await expect(popover).toBeVisible();
+  await page.click('button[popovertarget=popover1] span');
+  await expect(popover).toBeHidden();
+  await page.click('button[popovertarget=popover1] span');
+  await expect(popover).toBeVisible();
 });
 
 test('clicking button[popovertarget=popover1] should set button aria-expanded attribute appropriately', async ({
@@ -132,6 +147,10 @@ test('clicking button[popovertarget=shadowedNestedPopover] should hide open nest
   await expect(
     await popover.evaluate((node) => node.showPopover()),
   ).toBeUndefined();
+  await expect(popover).toBeVisible();
+  await page.click('button[popovertarget=shadowedNestedPopover]');
+  await expect(popover).toBeHidden();
+  await page.click('button[popovertarget=shadowedNestedPopover]');
   await expect(popover).toBeVisible();
   await page.click('button[popovertarget=shadowedNestedPopover]');
   await expect(popover).toBeHidden();


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&usecapture)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->
In a misinterpretation of the spec in #86 a regression was introduced whereby the invoker can cause toggles to be no-ops. The reason is largely to do with the `nearestInclusiveTargetPopoverForInvoker` which was not written close to the spec, instead it was using `nearestInclusivePopover(target.popoverTarget)` which is not appropriate if the target contained nested elements like spans, or a composed event came through a shadow boundary.

This fixes that by rewriting these algos to use the spec methodology.


## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._
Tests should cover these scenarios.

Try clicking the `Click to toggle shadowed Popover (auto)` though, which should toggle, and you might find once it's visible it cannot be closed with the same button.

Try clicking the `Popover 1` button - click the button and it should work, click the _text_ (the span) and you'll see it won't.

## Show me
_Provide screenshots/animated gifs/videos if necessary._
