### PR TITLE
remove disconnected autoPopovers during topMostPopoverAncestor algo

### DIFF
--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -78,6 +78,7 @@ function topMostAutoPopover(document: Document): HTMLElement | null {
   const documentPopovers = autoPopoverList.get(document);
   for (const popover of documentPopovers || []) {
     if (!popover.isConnected) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       documentPopovers!.delete(popover);
     } else {
       return popover;

--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -75,7 +75,15 @@ function topMostClickedPopover(target: HTMLElement) {
 
 // https://html.spec.whatwg.org/#topmost-auto-popover
 function topMostAutoPopover(document: Document): HTMLElement | null {
-  return Array.from(autoPopoverList.get(document) || []).pop() || null;
+  const documentPopovers = autoPopoverList.get(document);
+  for (const popover of documentPopovers || []) {
+    if (!popover.isConnected) {
+      documentPopovers!.delete(popover);
+    } else {
+      return popover;
+    }
+  }
+  return null;
 }
 
 // https://html.spec.whatwg.org/#nearest-inclusive-open-popover

--- a/tests/edge-cases.spec.ts
+++ b/tests/edge-cases.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test('removing an autoPopover from document doesnt crash page', async ({
+  page,
+}) => {
+  const popover = (await page.locator('#popover1')).nth(0);
+  await expect(popover).toBeHidden();
+  await expect(
+    await popover.evaluate((node) => node.showPopover()),
+  ).toBeUndefined();
+  await expect(popover).toBeVisible();
+  await expect(await popover.evaluate((node) => node.remove())).toBeUndefined();
+  const popover2 = (await page.locator('#popover2')).nth(0);
+  await expect(
+    await popover2.evaluate((node) => node.showPopover()),
+  ).toBeUndefined();
+  await expect(popover2).toBeVisible();
+});

--- a/tests/edge-cases.spec.ts
+++ b/tests/edge-cases.spec.ts
@@ -4,7 +4,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto('/');
 });
 
-test('removing an autoPopover from document doesnt crash page', async ({
+test("removing an autoPopover from document doesn't crash page", async ({
   page,
 }) => {
   const popover = (await page.locator('#popover1')).nth(0);


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&topmostpopoverancestorloop)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->

Prior to this change, a popover removed from the document would still be in the autoPopovers set, and subsequently `topMostPopverAncestor` would return disconnected elements, causing `closeAllPopovers` to hit an infinite loop:

1. `hidePopover` is called
2. `closeAllPopovers` is called
3. `topMostPopoverAncestor` is called and returns disconnected element.
4. `hidePopover(topMost)` is called but returns false, as the element is disconnected.
5. `topMostPopoverAncestor` is called, but it returns the same element. Repeat step 4, infinite loop.

This commit alters `topMostAutoPopover` to check if the element is disconnected, and remove it from the set if so, only returning the first connected element.

1. `hidePopover` is called
2. `closeAllPopovers` is called
3. `topMostPopoverAncestor` is called, the first element is disconnected, so it skips and returns the first connected element.
4. `hidePopover(topMost)` is called and returns true.
5. No infinite loop.


## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._
I've added a new test file "edge-cases.spec". This includes a test which fails on the current build (times out due to the browser hanging), but passes with the changes.

## Show me
_Provide screenshots/animated gifs/videos if necessary._

Special thanks to @hmaurer for giving me an easy repro to this one!