### PR TITLE
Add support for `relatedTarget` property in `beforetoggle`

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -1,11 +1,13 @@
 export interface ToggleInit extends EventInit {
   oldState: string;
   newState: string;
+  relatedTarget?: EventTarget | null;
 }
 
 export class ToggleEvent extends Event {
   public oldState: string;
   public newState: string;
+  public relatedTarget?: EventTarget | null;
   constructor(
     type: string,
     { oldState = '', newState = '', ...init }: Partial<ToggleInit> = {},
@@ -13,6 +15,7 @@ export class ToggleEvent extends Event {
     super(type, init);
     this.oldState = String(oldState || '');
     this.newState = String(newState || '');
+    this.relatedTarget = init.relatedTarget || null;
   }
 }
 

--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -26,10 +26,10 @@ export function popoverTargetAttributeActivationBehavior(
   }
   if (element.popoverTargetAction === 'hide' && visibility === 'hidden') return;
   if (visibility === 'showing') {
-    hidePopover(popover, true, true);
+    hidePopover(popover, element, true, true);
   } else if (checkPopoverValidity(popover, false)) {
     popoverInvoker.set(popover, element);
-    showPopover(popover);
+    showPopover(popover, element);
   }
 }
 
@@ -208,7 +208,7 @@ function popoverFocusingSteps(subject: HTMLElement) {
 const previouslyFocusedElements = new WeakMap<HTMLElement, HTMLElement>();
 
 // https://html.spec.whatwg.org/#show-popover
-export function showPopover(element: HTMLElement) {
+export function showPopover(element: HTMLElement, invoker?: HTMLElement) {
   if (!checkPopoverValidity(element, false)) {
     return;
   }
@@ -219,6 +219,7 @@ export function showPopover(element: HTMLElement) {
         cancelable: true,
         oldState: 'closed',
         newState: 'open',
+        relatedTarget: invoker,
       }),
     )
   ) {
@@ -273,6 +274,7 @@ export function showPopover(element: HTMLElement) {
 // https://html.spec.whatwg.org/#hide-popover
 export function hidePopover(
   element: HTMLElement,
+  invoker?: HTMLElement,
   focusPreviousElement = false,
   fireEvents = false,
 ) {
@@ -294,6 +296,7 @@ export function hidePopover(
       new ToggleEvent('beforetoggle', {
         oldState: 'open',
         newState: 'closed',
+        relatedTarget: invoker,
       }),
     );
     if (!checkPopoverValidity(element, true)) {
@@ -323,7 +326,7 @@ function closeAllOpenPopovers(
 ) {
   let popover = topMostAutoPopover(document);
   while (popover) {
-    hidePopover(popover, focusPreviousElement, fireEvents);
+    hidePopover(popover, undefined, focusPreviousElement, fireEvents);
     popover = topMostAutoPopover(document);
   }
 }
@@ -356,7 +359,7 @@ export function hideAllPopoversUntil(
     getPopoverVisibilityState(lastToHide) === 'showing' &&
     autoPopoverList.get(document)?.size
   ) {
-    hidePopover(lastToHide, focusPreviousElement, fireEvents);
+    hidePopover(lastToHide, undefined, focusPreviousElement, fireEvents);
   }
 }
 

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -79,30 +79,31 @@ export function apply() {
     showPopover: {
       enumerable: true,
       configurable: true,
-      value() {
-        showPopover(this);
+      value(options?: { invoker?: HTMLElement }) {
+        showPopover(this, options?.invoker);
       },
     },
 
     hidePopover: {
       enumerable: true,
       configurable: true,
-      value() {
-        hidePopover(this, true, true);
+      value(options?: { invoker?: HTMLElement }) {
+        hidePopover(this, options?.invoker, true, true);
       },
     },
 
     togglePopover: {
       enumerable: true,
       configurable: true,
-      value(force: boolean) {
+      value(options?: { force?: boolean; invoker?: HTMLElement }) {
         if (
-          (visibilityState.get(this) === 'showing' && force === undefined) ||
-          force === false
+          (visibilityState.get(this) === 'showing' &&
+            options?.force === undefined) ||
+          options?.force === false
         ) {
-          hidePopover(this, true, true);
-        } else if (force === undefined || force === true) {
-          showPopover(this);
+          hidePopover(this, options?.invoker, true, true);
+        } else if (options?.force === undefined || options?.force === true) {
+          showPopover(this, options?.invoker);
         }
       },
     },


### PR DESCRIPTION
This implements the idea in https://github.com/whatwg/html/issues/9111#issuecomment-1556131807

This adds:
- `showPopover(options?: { invoker?: HTMLelement });`
- `hidePopover(options?: { invoker?: HTMLElement });`

And it modifies `togglePopover(force: boolean)` to `togglePopover(options?: { force?: boolean, invoker?: element })`.

And the `invoker` parameter is automatically set as the `relatedTarget` property of all `beforetoggle` events. That property is automatically set when used with the `popovertarget` attribute.

This is a bit early, since there hasn't been any decision in WHATWG, but it *seems* like an obvious thing to add. I'd wait with merging this PR until a decision has been. And also I haven't written any tests yet.