### PR TITLE
tweak styles & guard some code in older browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
           </ul>
         </div>
       </div>
+      <dialog popover>I'm a dialog!</dialog>
       <div id="host"></div>
 
       <script type="module">

--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -1,5 +1,11 @@
 import { queuePopoverToggleEventTask, ToggleEvent } from './events.js';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const ShadowRoot = globalThis.ShadowRoot || function () {};
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const HTMLDialogElement = globalThis.HTMLDialogElement || function () {};
+
 const topLayerElements = new WeakMap<Document, Set<HTMLElement>>();
 const autoPopoverList = new WeakMap<Document, Set<HTMLElement>>();
 export const visibilityState = new WeakMap<HTMLElement, 'hidden' | 'showing'>();
@@ -87,6 +93,14 @@ function topMostAutoPopover(document: Document): HTMLElement | null {
   return null;
 }
 
+export function getRootNode(node: Node): Node {
+  if (typeof node.getRootNode === 'function') {
+    return node.getRootNode();
+  }
+  if (node.parentNode) return getRootNode(node.parentNode);
+  return node;
+}
+
 // https://html.spec.whatwg.org/#nearest-inclusive-open-popover
 function nearestInclusiveOpenPopover(
   node: Node | null,
@@ -99,7 +113,7 @@ function nearestInclusiveOpenPopover(
     ) {
       return node;
     }
-    node = node.parentElement || node.getRootNode();
+    node = node.parentElement || getRootNode(node);
     if (node instanceof ShadowRoot) node = node.host;
     if (node instanceof Document) return;
   }
@@ -112,7 +126,7 @@ function nearestInclusiveTargetPopoverForInvoker(
   while (node) {
     const nodePopover = (node as HTMLButtonElement).popoverTargetElement;
     if (nodePopover) return nodePopover;
-    node = node.parentElement || node.getRootNode();
+    node = node.parentElement || getRootNode(node);
     if (node instanceof ShadowRoot) node = node.host;
     if (node instanceof Document) return;
   }

--- a/src/popover.css
+++ b/src/popover.css
@@ -34,11 +34,17 @@ in a later release. */
   [popover]:not(.\:popover-open, dialog[open]) {
     display: revert;
   }
+  [anchor]:open {
+    inset: auto;
+  }
 }
 
 @supports selector([popover]:popover-open) {
   [popover]:not(.\:popover-open, dialog[open]) {
     display: revert;
+  }
+  [anchor]:popover-open {
+    inset: auto;
   }
 }
 /* stylelint-enable selector-class-pattern */

--- a/src/popover.css
+++ b/src/popover.css
@@ -34,18 +34,24 @@ in a later release. */
   [popover]:not(.\:popover-open, dialog[open]) {
     display: revert;
   }
-  [anchor]:open {
+
+  /* stylelint-disable selector-pseudo-class-no-unknown */
+  [anchor]:is(:open) {
     inset: auto;
   }
+  /* stylelint-enable selector-pseudo-class-no-unknown */
 }
 
 @supports selector([popover]:popover-open) {
   [popover]:not(.\:popover-open, dialog[open]) {
     display: revert;
   }
-  [anchor]:popover-open {
+
+  /* stylelint-disable selector-pseudo-class-no-unknown */
+  [anchor]:is(:popover-open) {
     inset: auto;
   }
+  /* stylelint-enable selector-pseudo-class-no-unknown */
 }
 /* stylelint-enable selector-class-pattern */
 

--- a/src/popover.css
+++ b/src/popover.css
@@ -5,34 +5,67 @@
   padding: 0.25em;
   width: fit-content;
   height: fit-content;
-  border: solid;
-  background: canvas;
+  border-width: initial;
+  border-color: initial;
+  border-image: initial;
+  border-style: solid;
+  background-color: canvas;
   color: canvastext;
   overflow: auto;
   margin: auto;
 }
 
 /* stylelint-disable selector-class-pattern */
+[popover]:not(.\:popover-open) {
+  display: none;
+}
+
+[popover]:is(dialog[open]) {
+  display: revert;
+}
+
+[anchor].\:popover-open {
+  inset: auto;
+}
 
 /* This older `:open` pseudo selector is deprecated and support will be removed
 in a later release. */
-@supports not selector([popover]:open) {
+@supports selector([popover]:open) {
   [popover]:not(.\:popover-open, dialog[open]) {
-    display: none;
-  }
-
-  [anchor].\:popover-open {
-    inset: auto;
+    display: revert;
   }
 }
 
-@supports not selector([popover]:popover-open) {
+@supports selector([popover]:popover-open) {
   [popover]:not(.\:popover-open, dialog[open]) {
-    display: none;
-  }
-
-  [anchor].\:popover-open {
-    inset: auto;
+    display: revert;
   }
 }
 /* stylelint-enable selector-class-pattern */
+
+@supports not (background-color: canvas) {
+  [popover] {
+    background-color: white;
+    color: black;
+  }
+}
+
+@supports (width: -moz-fit-content) {
+  [popover] {
+    /* stylelint-disable value-no-vendor-prefix */
+    width: -moz-fit-content;
+    height: -moz-fit-content;
+    /* stylelint-enable value-no-vendor-prefix */
+  }
+}
+
+@supports not (inset: 0) {
+  [popover] {
+    /* stylelint-disable declaration-block-no-redundant-longhand-properties */
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    /* stylelint-enable declaration-block-no-redundant-longhand-properties */
+  }
+}

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -1,5 +1,6 @@
 import { ToggleEvent } from './events.js';
 import {
+  getRootNode,
   hideAllPopoversUntil,
   hidePopover,
   lightDismissOpenPopovers,
@@ -7,6 +8,9 @@ import {
   showPopover,
   visibilityState,
 } from './popover-helpers.js';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const ShadowRoot = globalThis.ShadowRoot || function () {};
 
 export function isSupported() {
   return (
@@ -152,7 +156,7 @@ export function apply() {
             popoverTargetAssociatedElements.delete(this);
             return null;
           }
-          const root = this.getRootNode();
+          const root = getRootNode(this);
           const idref = this.getAttribute('popovertarget');
           if (
             (root instanceof Document || root instanceof ShadowRoot) &&
@@ -190,7 +194,7 @@ export function apply() {
     if (!(target instanceof Element) || target?.shadowRoot) {
       return;
     }
-    const root = target.getRootNode();
+    const root = getRootNode(target);
     if (!(root instanceof ShadowRoot || root instanceof Document)) {
       return;
     }


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&olderbrowsers)

<!--
## Description
Uncomment if you want to provide a custom description.
-->

This PR changes the CSS and JS in some ways that support various combinations of esoteric browsers+flags. It fixes the following:

- Chrome 113 with Experimental Web Platform Features enabled. This browser supports native popover but with the `:open` psuedo selector (not `:popover-open`).
- Safari Technical Preview 166-171. These browsers support `popover` but either with `:open`, or both `:open` _and_ `:popover-open`.
- Older versions of Chromium such as 87, which includes alts like Qutebrowser, and older versions of Firefox such as Firefox 91, which includes alts like Seamonkey, Watefox Classic. These browsers don't support `@supports selector()`, `width: fit-content`, `inset`, nor do they support `node.getRootNode()`, `ShadowRoot`, or `HTMLDialogElement`. Luckily these are all fairly straightforward things to smooth over.

As a result of the combinatorial complexity of trying to support `:popover-open` and `:open` as well as support browsers which themselves don't support `@supports selector()`, the easiest solution is to avoid `@supports not(selector(...))` and instead use `display: revet` for the browsers that support `@supports selector()` and some combination of `:popover-open`/`:open`.

This should raise the support level to old browsers such as Firefox 91, Chrome ~80

I haven't done any testing in old Trident browsers like old Edge/IE.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._
Compare this branch to main in the following browsers:

 - Safari Technical Preview 166
 - Chrome 113 (with Experimental Web Platform Features enabled)
 - Seamonkey 2.53.16 (Firefox 91)
 - Waterfox Classic 2022.11
 - Qutebrowser 2.5.4 (Chromium 87)


## Show me
_Provide screenshots/animated gifs/videos if necessary._
