### PR TITLE
fix: querySelector APIs support null/undefined (closes #104)

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -34,8 +34,8 @@ const nonEscapedPopoverSelector = /(^|[^\\]):popover-open\b/g;
 export function apply() {
   window.ToggleEvent = window.ToggleEvent || ToggleEvent;
 
-  function rewriteSelector(selector: string) {
-    if (selector.includes(':popover-open')) {
+  function rewriteSelector(selector: string | null | undefined) {
+    if (selector?.includes(':popover-open')) {
       selector = selector.replace(
         nonEscapedPopoverSelector,
         '$1.\\:popover-open',


### PR DESCRIPTION
To demonstrate this, you can see this in action if you go to the [demo](https://popover-polyfill.netlify.app/) in a browser that doesn't natively implement popover, and in the console execute:

```js
document.querySelector(null);
```

This causes some interop issues with other 3rd party libraries.

## Expected behavior
`document.querySelector` does not throw an error, and returns null.

## Actual behavior
Error thrown: Uncaught TypeError: can't access property "includes", selector is null

Firefox:  
![image](https://github.com/oddbird/popover-polyfill/assets/3483866/dd5dea9a-c6bd-45ba-a8b0-a177769ebd86)
