### PR TITLE
fix: querySelector APIs support null/undefined (closes #104)

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -34,7 +34,7 @@ const nonEscapedPopoverSelector = /(^|[^\\]):popover-open\b/g;
 export function apply() {
   window.ToggleEvent = window.ToggleEvent || ToggleEvent;
 
-  function rewriteSelector(selector: string | null | undefined) {
+  function rewriteSelector(selector: string) {
     if (selector?.includes(':popover-open')) {
       selector = selector.replace(
         nonEscapedPopoverSelector,


### PR DESCRIPTION
See #105 

Fixes #104 