### PR TITLE
ensure `:open` styles are applied for browsers that claim support

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,8 @@
 {
   "extends": "stylelint-config-standard",
   "rules": {
+    "selector-class-pattern": null,
+    "selector-pseudo-class-no-unknown": null,
     "selector-type-no-unknown": null
   }
 }

--- a/src/popover.css
+++ b/src/popover.css
@@ -35,6 +35,10 @@ in a later release. */
     display: revert;
   }
 
+  [popover]:not(:open) {
+    display: none;
+  }
+
   /* stylelint-disable selector-pseudo-class-no-unknown */
   [anchor]:is(:open) {
     inset: auto;
@@ -45,6 +49,10 @@ in a later release. */
 @supports selector([popover]:popover-open) {
   [popover]:not(.\:popover-open, dialog[open]) {
     display: revert;
+  }
+
+  [popover]:not(:popover-open) {
+    display: none;
   }
 
   /* stylelint-disable selector-pseudo-class-no-unknown */

--- a/src/popover.css
+++ b/src/popover.css
@@ -15,7 +15,6 @@
   margin: auto;
 }
 
-/* stylelint-disable selector-class-pattern */
 [popover]:not(.\:popover-open) {
   display: none;
 }
@@ -28,40 +27,35 @@
   inset: auto;
 }
 
-/* This older `:open` pseudo selector is deprecated and support will be removed
-in a later release. */
+/* This older `:open` pseudo selector is deprecated
+   and support will be removed in a later release. */
 @supports selector([popover]:open) {
-  [popover]:not(.\:popover-open, dialog[open]) {
-    display: revert;
-  }
-
   [popover]:not(:open) {
     display: none;
   }
 
-  /* stylelint-disable selector-pseudo-class-no-unknown */
-  [anchor]:is(:open) {
-    inset: auto;
-  }
-  /* stylelint-enable selector-pseudo-class-no-unknown */
-}
-
-@supports selector([popover]:popover-open) {
   [popover]:not(.\:popover-open, dialog[open]) {
     display: revert;
   }
 
+  [anchor]:is(:open) {
+    inset: auto;
+  }
+}
+
+@supports selector([popover]:popover-open) {
   [popover]:not(:popover-open) {
     display: none;
   }
 
-  /* stylelint-disable selector-pseudo-class-no-unknown */
+  [popover]:not(.\:popover-open, dialog[open]) {
+    display: revert;
+  }
+
   [anchor]:is(:popover-open) {
     inset: auto;
   }
-  /* stylelint-enable selector-pseudo-class-no-unknown */
 }
-/* stylelint-enable selector-class-pattern */
 
 @supports not (background-color: canvas) {
   [popover] {
@@ -72,20 +66,13 @@ in a later release. */
 
 @supports (width: -moz-fit-content) {
   [popover] {
-    /* stylelint-disable value-no-vendor-prefix */
-    width: -moz-fit-content;
-    height: -moz-fit-content;
-    /* stylelint-enable value-no-vendor-prefix */
+    width: fit-content;
+    height: fit-content;
   }
 }
 
 @supports not (inset: 0) {
   [popover] {
-    /* stylelint-disable declaration-block-no-redundant-longhand-properties */
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    /* stylelint-enable declaration-block-no-redundant-longhand-properties */
+    inset: 0;
   }
 }


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&gnomeweb)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

## Description

Gnome Web applies blocks inside `@supports (:open)` despite supporting `popover` or having UA styles for `popover`.

This applies the default UA style of `display:none` for a hidden popover, to avoid situations with Gnome Web where popovers remain always open.

## Steps to test/reproduce

Visit the demo site in Gnome Web.


/cc @webreflection if you'd kindly test this in Gnome Web for me that would be very helpful!