### PR TITLE
drop :open styles

### DIFF
--- a/src/popover.css
+++ b/src/popover.css
@@ -28,20 +28,6 @@
   inset: auto;
 }
 
-/* This older `:open` pseudo selector is deprecated and support will be removed
-in a later release. */
-@supports selector([popover]:open) {
-  [popover]:not(.\:popover-open, dialog[open]) {
-    display: revert;
-  }
-
-  /* stylelint-disable selector-pseudo-class-no-unknown */
-  [anchor]:is(:open) {
-    inset: auto;
-  }
-  /* stylelint-enable selector-pseudo-class-no-unknown */
-}
-
 @supports selector([popover]:popover-open) {
   [popover]:not(.\:popover-open, dialog[open]) {
     display: revert;


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&remove-open)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

## Description

Older versions of Chrome with experimental web platform features turned on (Chrome 113) supported the `:open` pseudo class to determine if a popover was open or not. We have support code for this in the form of CSS that checks `@supports ([popover]:open)`.

The problem is that now causes issues with certain versions of WebKit, which claim to support `:open` and pass the CSS check, only to _unapply_ the popover styles but not actually support `popover`. In other words, there are versions of WebKit - such as Gnome Web - for which this breaks.

Given the popularity of Gnome Web (a fairly small % of total market share) compared with Chrome 113 with Experimental Web Platform Features enabled (an even smaller %), it makes sense to _remove_ this CSS in order to support browsers like Gnome Web.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._
Visit the demo page in Gnome Web. Everything is broken.
Visit this PR demo page in Gnome Web. Everything should work.

/cc @WebReflection

## Show me
_Provide screenshots/animated gifs/videos if necessary._
