### PR TITLE
Assign adoptedStyleSheets rather than push

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -111,7 +111,7 @@ export function injectStyles(root: Document | ShadowRoot) {
       root.append(sheet);
     }
   } else {
-    root.adoptedStyleSheets.push(popoverStyleSheet);
+    root.adoptedStyleSheets = [...root.adoptedStyleSheets, popoverStyleSheet];
   }
 }
 


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&adoptedstylesheets_observablearray)

## Description

Some older browsers such as Chrome 98 have `adoptedStyleSheets` but it is a frozen array, rather than an `ObservableArray`, and can only be assigned to rather than `push()`ed to. Pushing to a frozen array causes an error to be thrown and so the polyfill doesn't work in those browsers if we continue to use push.

The fix for this is to always use an assignment on the array, it's a little slower the impact will be negligible.

See https://chromestatus.com/feature/5638996492288000 for some more detail.


## Steps to test/reproduce

- Visit https://popover-polyfill.netlify.app/ in Chrome <99 (I tested Chrome 96 for example).
- Note that the styles haven't loaded and popovers are all visible.
- Visit the console and note the error `TypeError: Cannot add property 0, object is not extensible`.

## Show me

![a screenshot of Chrome 96 showing the error condition described above. There are two windows open, one demonstrating the Chrome version (96) and the other with the popover demo page open; the devtools are open showing the error and the demo page is unstyled, with all popovers showing.](https://github.com/oddbird/popover-polyfill/assets/118266/0b9b728f-e3ad-456e-bf88-6aeb9a621ddb)
