### PR TITLE
upgrade to typescript@5.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^3.0.3",
         "ts-node": "^10.9.1",
-        "typescript": "5.1.6"
+        "typescript": "^5.2.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4127,9 +4127,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -7137,9 +7137,9 @@
       }
     },
     "typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.3",
     "ts-node": "^10.9.1",
-    "typescript": "5.1.6"
+    "typescript": "^5.2.2"
   },
   "lint-staged": {
     "*.{js,ts}": [

--- a/src/index-fn.ts
+++ b/src/index-fn.ts
@@ -1,23 +1,35 @@
 interface PopoverToggleTargetElementInvoker {
-  popoverTargetElement: HTMLElement | null;
-  popoverTargetAction: 'toggle' | 'show' | 'hide';
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/popoverTargetAction) */
+  popoverTargetAction: string;
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/popoverTargetElement) */
+  popoverTargetElement: Element | null;
 }
 
 declare global {
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ToggleEvent) */
   interface ToggleEvent extends Event {
-    oldState: string;
-    newState: string;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ToggleEvent/newState) */
+    readonly newState: string;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ToggleEvent/oldState) */
+    readonly oldState: string;
   }
+
   interface HTMLElement {
-    popover: 'auto' | 'manual' | null;
-    showPopover(): void;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/popover) */
+    popover: string | null;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidePopover) */
     hidePopover(): void;
-    togglePopover(): void;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/showPopover) */
+    showPopover(): void;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover) */
+    togglePopover(force?: boolean): void;
   }
+
   /* eslint-disable @typescript-eslint/no-empty-interface */
   interface HTMLButtonElement extends PopoverToggleTargetElementInvoker {}
   interface HTMLInputElement extends PopoverToggleTargetElementInvoker {}
   /* eslint-enable @typescript-eslint/no-empty-interface */
+
   interface Window {
     ToggleEvent: ToggleEvent;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,37 @@
 import { apply, isSupported } from './popover.js';
 
 interface PopoverToggleTargetElementInvoker {
-  popoverTargetElement: HTMLElement | null;
-  popoverTargetAction: 'toggle' | 'show' | 'hide';
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/popoverTargetAction) */
+  popoverTargetAction: string;
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/popoverTargetElement) */
+  popoverTargetElement: Element | null;
 }
 
 declare global {
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ToggleEvent) */
   interface ToggleEvent extends Event {
-    oldState: string;
-    newState: string;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ToggleEvent/newState) */
+    readonly newState: string;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ToggleEvent/oldState) */
+    readonly oldState: string;
   }
+
   interface HTMLElement {
-    popover: 'auto' | 'manual' | null;
-    showPopover(): void;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/popover) */
+    popover: string | null;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidePopover) */
     hidePopover(): void;
-    togglePopover(): void;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/showPopover) */
+    showPopover(): void;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover) */
+    togglePopover(force?: boolean): void;
   }
+
   /* eslint-disable @typescript-eslint/no-empty-interface */
   interface HTMLButtonElement extends PopoverToggleTargetElementInvoker {}
   interface HTMLInputElement extends PopoverToggleTargetElementInvoker {}
   /* eslint-enable @typescript-eslint/no-empty-interface */
+
   interface Window {
     ToggleEvent: ToggleEvent;
   }

--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -23,7 +23,7 @@ export function popoverTargetAttributeActivationBehavior(
   element: HTMLButtonElement | HTMLInputElement,
 ) {
   const popover = element.popoverTargetElement;
-  if (!popover) {
+  if (!(popover instanceof HTMLElement)) {
     return;
   }
   const visibility = getPopoverVisibilityState(popover);
@@ -125,7 +125,7 @@ function nearestInclusiveTargetPopoverForInvoker(
 ): HTMLElement | undefined {
   while (node) {
     const nodePopover = (node as HTMLButtonElement).popoverTargetElement;
-    if (nodePopover) return nodePopover;
+    if (nodePopover instanceof HTMLElement) return nodePopover;
     node = node.parentElement || getRootNode(node);
     if (node instanceof ShadowRoot) node = node.host;
     if (node instanceof Document) return;
@@ -410,7 +410,7 @@ function setInvokerAriaExpanded(
     initialAriaExpandedValue.set(el, el.getAttribute('aria-expanded'));
   }
   const popover = el.popoverTargetElement;
-  if (popover && popover.popover === 'auto') {
+  if (popover instanceof HTMLElement && popover.popover === 'auto') {
     el.setAttribute('aria-expanded', String(force));
   } else {
     const initialValue = initialAriaExpandedValue.get(el);


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&ts522)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

## Description

TypeScript recently added definitions for `popover` which conflict with the ones in this repository.

This updates the TS definitions to be compatible with those from TypeScript, so that users of older versions of TypeScript will still get the types, and for users of newer versions the code won't run into type conflicts.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._
```console
$ git checkout origin/main -f
$ npm i typescript@latest -D
$ npm run build # observe the errrors!
```

## Show me
_Provide screenshots/animated gifs/videos if necessary._
N/A