### PR TITLE
use :where for selectors

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -35,8 +35,10 @@ function patchSelectorFn<K extends string>(
 
 const nonEscapedPopoverSelector = /(^|[^\\]):popover-open\b/g;
 
+// To emulate a UA stylesheet which is the lowest priority in the cascade,
+// all selectors must be wrapped in a :where() which has a specificity of zero.
 const styles = `
-  [popover] {
+  :where([popover]) {
     position: fixed;
     z-index: 2147483647;
     inset: 0;
@@ -53,34 +55,34 @@ const styles = `
     margin: auto;
   }
 
-  [popover]:is(dialog[open]) {
+  :where(dialog[popover][open]) {
     display: revert;
   }
 
-  [anchor].\\:popover-open {
+  :where([anchor].\\:popover-open) {
     inset: auto;
   }
 
-  [anchor]:is(:popover-open) {
+  :where([anchor]:popover-open) {
     inset: auto;
   }
 
   @supports not (background-color: canvas) {
-    [popover] {
+    :where([popover]) {
       background-color: white;
       color: black;
     }
   }
 
   @supports (width: -moz-fit-content) {
-    [popover] {
+    :where([popover]) {
       width: -moz-fit-content;
       height: -moz-fit-content;
     }
   }
 
   @supports not (inset: 0) {
-    [popover] {
+    :where([popover]) {
       top: 0;
       left: 0;
       right: 0;
@@ -88,7 +90,7 @@ const styles = `
     }
   }
 
-  [popover]:not(.\\:popover-open) {
+  :where([popover]:not(.\\:popover-open)) {
     display: none;
   }
 `;


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&where)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

## Description

This wraps all selectors in a `:where()` (and also drops the redundant `:is()` which was there to lower specificity).

I tested this change on GitHub (where we use this polyfill) and I couldn't spot any regressions, styling worked as expected, and I spotted a couple of areas where we could lower our specificity. So I think this is is a worthwhile change.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._
This is effectively a no-op change, so no steps to reproduce.

## Show me
_Provide screenshots/animated gifs/videos if necessary._
This is effectively a no-op change, so no steps to reproduce.