### PR TITLE
prepend popover stylesheet

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -108,12 +108,12 @@ export function injectStyles(root: Document | ShadowRoot) {
     const sheet = document.createElement('style');
     sheet.textContent = styles;
     if (root instanceof Document) {
-      root.head.append(sheet);
+      root.head.prepend(sheet);
     } else {
-      root.append(sheet);
+      root.prepend(sheet);
     }
   } else {
-    root.adoptedStyleSheets = [...root.adoptedStyleSheets, popoverStyleSheet];
+    root.adoptedStyleSheets = [popoverStyleSheet, ...root.adoptedStyleSheets];
   }
 }
 


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&CHANGE_ME)

## Description

This may go some of the way to fixing #147 which is still an issue for users, despite #153 which dropped selector specificity down to 0,0,0. Right now if a selector is used that has a specificity of 0,0,0, the polyfill will _still_ potentially override it as the popover styles get _appended_ to the head/adoptedStyleSheets, and as such will be lower in the cascade.

This change ensures that the popover stylesheet is _prepended_ rather than _appended_, which means it will appear as high up in the cascade as possible, rather than potentially at the bottom.

## Steps to test/reproduce
N/A

## Show me
N/A
