### PR TITLE
allow esc to be defaultpreventable

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -323,7 +323,11 @@ export function apply() {
   const onKeydown = (event: Event) => {
     const key = (event as KeyboardEvent).key;
     const target = event.target as Element;
-    if (target && (key === 'Escape' || key === 'Esc')) {
+    if (
+      !event.defaultPrevented &&
+      target &&
+      (key === 'Escape' || key === 'Esc')
+    ) {
       hideAllPopoversUntil(target.ownerDocument, true, true);
     }
   };


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&CHANGE_ME)

## Description

Browsers' native `popover` support allows for the `Esc` keypress to be preventable, which means that the popover won't close.

This is useful for capturing the `Esc` key behaviour from _within_ a popover to do other things without closing the popover.

Currently the polyfill does not allow for this. This PR checks the flag to ensure default hasn't been prevented.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._
I can follow up with steps/tests if we feel it necessary (time is short right now). 

## Show me
_Provide screenshots/animated gifs/videos if necessary._
