### PR TITLE
prevent default on clicks to avoid firefox crash

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -316,6 +316,7 @@ export function apply() {
     const invoker = target.closest('[popovertargetaction],[popovertarget]');
     if (invoker) {
       popoverTargetAttributeActivationBehavior(invoker as HTMLButtonElement);
+      event.preventDefault();
       return;
     }
   };


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&CHANGE_ME)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

## Description

This fixes https://github.com/oddbird/popover-polyfill/issues/139. Currently the demo page crashes in Firefox (without popovers enabled) if you click the "Click to toggle shadowed popover" button.

Looking through [a crash log](https://crash-stats.mozilla.org/report/index/7ac206de-9229-402a-9e6f-31ee80231019), we can see this is because Firefox tries to handle the popover using their popover logic, but the logic isn't guarded to check the feature flag, and it tries to get the element by its ID, which is empty. The empty id check fails for some reason, and we end up with a crash:

 - Starting at Frame 6 we call [`mTarget->postHandleEvent(aVisitor);`](https://hg.mozilla.org/releases/mozilla-release/file/e26ce7fb8b2358ad45a84d34b1f5b6a1cc59d7fb/dom/events/EventDispatcher.cpp#l436)
 - `postHandleEvent` calls [`HandlePopoverTargetAction();`](https://hg.mozilla.org/releases/mozilla-release/file/e26ce7fb8b2358ad45a84d34b1f5b6a1cc59d7fb/dom/html/HTMLButtonElement.cpp#l241)
 - `HandlePopoverTargetAction` isn't adequately guarded so calls [`GetEffectivePopoverTargetElement();`](https://hg.mozilla.org/releases/mozilla-release/file/e26ce7fb8b2358ad45a84d34b1f5b6a1cc59d7fb/dom/html/nsGenericHTMLElement.cpp#l2855)
 - This also isn't guarded and so calls [`GetAttrAssociatedElement(nsGkAtoms::popovertarget);`](https://hg.mozilla.org/releases/mozilla-release/file/e26ce7fb8b2358ad45a84d34b1f5b6a1cc59d7fb/dom/html/nsGenericHTMLElement.cpp#l2846)
 - Which calls [`docOrShadowRoot->GetElementById(valueAtom);`](https://hg.mozilla.org/releases/mozilla-release/file/e26ce7fb8b2358ad45a84d34b1f5b6a1cc59d7fb/dom/base/Element.cpp#l1744)
 - At this point `aElementId` is an `Atom`, but it should be the empty atom, and it should hit [`MOZ_UNLIKELY(aElementId == nsGkAtoms::_empty)`](https://hg.mozilla.org/releases/mozilla-release/file/e26ce7fb8b2358ad45a84d34b1f5b6a1cc59d7fb/dom/base/DocumentOrShadowRoot.cpp#l244) and return a `nullptr`, but for some reason it doesn't (it's not the empty atom?)
 - So instead we fall through and call [`mIdentifierMap.GetEntry(aElementId)`](https://hg.mozilla.org/releases/mozilla-release/file/e26ce7fb8b2358ad45a84d34b1f5b6a1cc59d7fb/dom/base/DocumentOrShadowRoot.cpp#l249)
 - The rest of the crash log tries to get this Atom from the has table, but fails and crashes - presumably this is a nullptr or OOB check fail.

So, this is definitely a bug in Firefox. Exceptions like this shouldn't happen, I've filed https://bugzilla.mozilla.org/show_bug.cgi?id=1868740 and I'll work on a patch to fix it.

In the meantime, however, we have an opportunity to fix it ourselves, because `postHandleEvent()` will only be called if the event's default wasn't prevented. Consequently, simply adding `event.preventDefault()` in our JS fixes this issue.

## Steps to test/reproduce

- Open Firefox (118+)
- Ensure dom.element.popover.enabled is set to false
- Visit https://popover-polyfill.netlify.app/
- Click the button labelled "Click to toggle shadowed Popover"
- Observe a crash (example: https://crash-stats.mozilla.org/report/index/7ac206de-9229-402a-9e6f-31ee80231019)


## Show me
N/A
