### PR TITLE
Improve ESM Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ After installing, you’ll need to use appropriate tooling to use
 For most tooling such as Vite, Webpack, and Parcel, that will look like this:
 
 ```js
-import '@oddbird/popover-polyfill;
+import '@oddbird/popover-polyfill';
 ```
 
 If you want to manually apply the polyfill, you can instead import the

--- a/README.md
+++ b/README.md
@@ -45,9 +45,21 @@ npm install @oddbird/popover-polyfill
 After installing, you’ll need to use appropriate tooling to use
 `node_modules/@oddbird/popover-polyfill/dist/popover.js`.
 
+For most tooling such as Vite, Webpack, and Parcel, that will look like this:
+
+```js
+import '@oddbird/popover-polyfill;
+```
+
 If you want to manually apply the polyfill, you can instead import the
 `isSupported` and `apply` functions directly from
 `node_modules/@oddbird/popover-polyfill/dist/popover-fn.js` file.
+
+With most tooling:
+
+```js
+import { apply, isSupported } from '@oddbird/popover-polyfill/fn';
+```
 
 ### Via CDN
 


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&wesiscool)

Hello! We recently had a 500ms render blocking script load, and I think it stems back to the docs for using this being a bit confusing on how to import the polyfill. I'm clarifying how to import the polyfill with almost all JS tooling. In fact, I can't think of any tooling that doesn't support this method. 