### PR TITLE
Allow synthetic click events to target popovers

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -303,7 +303,6 @@ export function apply() {
   applyPopoverInvokerElementMixin(HTMLInputElement);
 
   const handleInvokerActivation = (event: Event) => {
-    if (!event.isTrusted) return;
     // Composed path allows us to find the target within shadowroots
     const target = event.composedPath()[0] as HTMLElement;
     if (!(target instanceof Element) || target?.shadowRoot) {


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&CHANGE_ME)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

## Description

In https://github.com/philc/vimium/issues/4369 it has been noted that popovers don't work with the Firefox "Vimium" extension. This is, I suspect, because Vimium is synthesising click events and the popover polyfill checks if the event `isTrusted` (coming from the browser and not from scripts).

Trying to reproduce this in https://codepen.io/keithamus/pen/MWxJxOR we can see that the polyfill - when used - renders the button inert due to this guard, however native popover does not have the same guard and so in browsers with native popover (Chrome, WebKit) it is _not_ inert.

Consequently we should remove this guard to ensure behaviour aligns with native. 

## Related Issue(s)

https://github.com/philc/vimium/issues/4369


## Steps to test/reproduce

1. Open Firefox
2. Ensure `dom.element.popover.enabled` is set to `false`
3. Open https://codepen.io/keithamus/pen/MWxJxOR
4. Click the button
5. EXPECTED: popover shows
6. ACTUAL: popover does not show.


## Show me
_Provide screenshots/animated gifs/videos if necessary._
