### PR TITLE
Ensure click events correctly cross out of ShadowDOM

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
           </ul>
         </div>
       </div>
+      <div id="popover12" popover>Popover 12</div>
       <dialog popover>I'm a dialog!</dialog>
       <div id="host"></div>
 
@@ -88,6 +89,15 @@
       <button popovertarget="notExist">Click to toggle nothing</button>
       <button id="crossTreeToggle">Click to toggle shadowed Popover</button>
       <button popovertargetaction="show" popovertarget="popover11">Menu</button>
+      <button popovertarget="popover12">
+        <span id="shadowInInvoker"></span>
+      </button>
+
+      <script type="module">
+        const host = document.getElementById('shadowInInvoker');
+        const shadowRoot = host.attachShadow({ mode: 'open' });
+        shadowRoot.innerHTML = `<span>Click to toggle Popover 12</span>`;
+      </script>
     </div>
   </body>
 </html>

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -304,7 +304,8 @@ export function apply() {
 
   const handleInvokerActivation = (event: Event) => {
     // Composed path allows us to find the target within shadowroots
-    const target = event.composedPath()[0] as HTMLElement;
+    const composedPath = event.composedPath() as HTMLElement[];
+    const target = composedPath[0];
     if (!(target instanceof Element) || target?.shadowRoot) {
       return;
     }
@@ -312,7 +313,9 @@ export function apply() {
     if (!(root instanceof ShadowRoot || root instanceof Document)) {
       return;
     }
-    const invoker = target.closest('[popovertargetaction],[popovertarget]');
+    const invoker = composedPath.find(
+      (el) => el.matches && el.matches('[popovertargetaction],[popovertarget]'),
+    );
     if (invoker) {
       popoverTargetAttributeActivationBehavior(invoker as HTMLButtonElement);
       event.preventDefault();

--- a/tests/triggers.spec.ts
+++ b/tests/triggers.spec.ts
@@ -215,12 +215,22 @@ test("assign null to invoker's 'popoverTargetElement' property should remove its
   ).toBeNull();
 });
 
-test('clicking button#crossTreeToggle then button#crossTreeToggle twice should show and hide popover in a different tree scope', async ({
+test('clicking button#crossTreeToggle should show then hide popover in a different tree scope', async ({
   page,
 }) => {
   const popover = (await page.locator('#shadowedPopover')).nth(0);
   await page.click('button#crossTreeToggle');
   await expect(popover).toBeVisible();
   await page.click('button#crossTreeToggle');
+  await expect(popover).toBeHidden();
+});
+
+test('clicking #shadowInInvoker should show then hide popover', async ({
+  page,
+}) => {
+  const popover = (await page.locator('#popover12')).nth(0);
+  await page.click('#shadowInInvoker');
+  await expect(popover).toBeVisible();
+  await page.click('#shadowInInvoker');
   await expect(popover).toBeHidden();
 });


### PR DESCRIPTION
## Related Issue(s)
#176 

## Steps to test/reproduce
- Populate the shadow dom of any element inside of a button that is a `popovertrigger`
- When a click originates from within the shadow dom, the popover is not triggers
