### PR TITLE
Add `isPolyfilled` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ With most tooling:
 import { apply, isSupported } from '@oddbird/popover-polyfill/fn';
 ```
 
+A special `isPolyfilled` function is also available, to detect if the Popover methods have been polyfilled:
+
+```js
+import { isPolyfilled } from '@oddbird/popover-polyfill/fn';
+```
+
 ### Via CDN
 
 For prototyping or testing, you can use the npm package via a Content Delivery

--- a/src/index-fn.ts
+++ b/src/index-fn.ts
@@ -35,4 +35,4 @@ declare global {
   }
 }
 
-export { apply, isSupported } from './popover.js';
+export { apply, isSupported, isPolyfilled } from './popover.js';

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -23,10 +23,9 @@ export function isSupported() {
 export function isPolyfilled() {
   // if the `showPopover` method is defined but is not "native code"
   // then we can infer it's been polyfilled
-  return (
-    document.body &&
-    document.body.showPopover &&
-    !document.body.showPopover.toString().match(/native code/i)
+  return Boolean(
+    document.body?.showPopover &&
+    !/native code/i.test(document.body.showPopover.toString())
   );
 }
 

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -20,6 +20,16 @@ export function isSupported() {
   );
 }
 
+export function isPolyfilled() {
+  // if the `showPopover` method is defined but is not "native code"
+  // then we can infer it's been polyfilled
+  return (
+    document.body &&
+    document.body.showPopover &&
+    !document.body.showPopover.toString().match(/native code/i)
+  );
+}
+
 function patchSelectorFn<K extends string>(
   object: Record<PropertyKey & K, unknown>,
   name: K,


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&blackhole)

## Description
This PR adds a `isPolyfilled` function to the public methods exposed by the polyfill.
The functions tests if the Popover API has been polyfilled, and it can be used to execute conditional code depending on if the Popover API is polyfilled or is native.

## Related Issue(s)
https://github.com/oddbird/popover-polyfill/issues/189