### PR TITLE
Add support for dialog popovers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
         Menu with shadowed popover
         <div id="menu-host"></div>
       </div>
-      <dialog popover>I'm a dialog!</dialog>
+      <dialog id="dialog" popover>This is a dialog</dialog>
       <div id="host"></div>
 
       <script type="module">
@@ -137,6 +137,7 @@
       <button popovertarget="menu-with-shadowed-popover">
         Toggle menu with shadowed nested popover
       </button>
+      <button popovertarget="dialog">Click to toggle dialog</button>
 
       <script type="module">
         const shadowInInvoker = document.getElementById('shadowInInvoker');

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -71,6 +71,14 @@ ${useLayer ? '@layer popover-polyfill {' : ''}
     margin: auto;
   }
 
+  :where([popover]:not(.\\:popover-open)) {
+    display: none;
+  }
+
+  :where(dialog[popover].\\:popover-open) {
+    display: block;
+  }
+
   :where(dialog[popover][open]) {
     display: revert;
   }
@@ -104,10 +112,6 @@ ${useLayer ? '@layer popover-polyfill {' : ''}
       right: 0;
       bottom: 0;
     }
-  }
-
-  :where([popover]:not(.\\:popover-open)) {
-    display: none;
   }
 ${useLayer ? '}' : ''}
 `;

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -78,3 +78,8 @@ test('popover as "invalid"', async ({ page }) => {
   const popover = (await page.locator('#popover6')).nth(0);
   await expect(popover).toBeFunctionalPopover();
 });
+
+test('dialog popover', async ({ page }) => {
+  const popover = (await page.locator('#dialog')).nth(0);
+  await expect(popover).toBeFunctionalPopover();
+});


### PR DESCRIPTION
Fixes #198 

@keithamus @mirisuzanne I see there was already a `dialog[popover]` in the demo page, but it wasn't being used or tested, and it looks to me like this additional style change was necessary to make it work. Let me know if I'm missing some context here.