### PR TITLE
Do not error if `window` is undefined

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -142,7 +142,9 @@ export function injectStyles(root: Document | ShadowRoot) {
 }
 
 export function apply() {
-  globalThis.ToggleEvent = globalThis.ToggleEvent || ToggleEvent;
+  if (typeof window === 'undefined') return;
+
+  window.ToggleEvent = window.ToggleEvent || ToggleEvent;
 
   function rewriteSelector(selector: string) {
     if (selector?.includes(':popover-open')) {


### PR DESCRIPTION
Better support for SSR environments by internally checking for `typeof window === 'undefined'` before applying polyfill.

Addresses https://github.com/oddbird/popover-polyfill/issues/192#issuecomment-2033194487