### PR TITLE
Add caveat about not polyfilling partial support

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ some caveats which will need accommodations:
   styles do use layers, you'll need to ensure the polyfill layer is declared
   first. (e.g. `@layer popover-polyfill, other, layers;`)
 
-- The polyfill will not work in browsers with partial popover support enabled or
-  attempt to make experimental support match the final spec.
+- The polyfill will not work in browsers with partial popover support enabled,
+  and will also not attempt to make experimental support match the final spec.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ some caveats which will need accommodations:
   styles do use layers, you'll need to ensure the polyfill layer is declared
   first. (e.g. `@layer popover-polyfill, other, layers;`)
 
+- The polyfill will not work in browsers with partial popover support enabled or
+  attempt to make experimental support match the final spec.
+
 ## Contributing
 
 Visit our [contribution guidelines](https://github.com/oddbird/popover-polyfill/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&partial)

## Description
In #208, a user reported the polyfill was not able to be applied in certain builds of Chromium where part of the popover spec was enabled as part of the compilation (as opposed to a feature flag).

This caveat intentionally doesn't specify versions, as it is a function of the engine version, the engine compilation, and a user setting.

## Related Issue(s)
Closes #208 