### PR TITLE
Add CommonJS build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "build:esm": "esbuild --bundle src/index.ts --outfile=dist/popover.js --format=esm --sourcemap",
     "build:esm-min": "esbuild --bundle src/index.ts --outfile=dist/popover.min.js --format=esm --minify --sourcemap",
     "build:esm-fn": "esbuild --bundle src/index-fn.ts --outfile=dist/popover-fn.js --format=esm --sourcemap",
+    "build:cjs": "esbuild --bundle src/index.ts --outfile=dist/popover.cjs.js --format=cjs --sourcemap",
     "clean": "rm -rf dist",
     "build": "run-s clean build:* types",
     "server:start": "esbuild --bundle src/index.ts --format=esm --servedir=. --outdir=dist --sourcemap --serve=\"${PORT:-3000}\" --log-level=\"${LEVEL:-info}\"",


### PR DESCRIPTION
## Description
This pull request adds a CommonJS (CJS) build script to the `@oddbird/popover-polyfill` package. This change allows the polyfill to be used in environments that require CommonJS modules.
This pull request includes a small change to the `package.json` file to add a new build script for CommonJS format.

## Build script addition:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R63): Added a new script `"build:cjs"` to bundle the source file `src/index.ts` into CommonJS format with source maps.

## Steps to test/reproduce
This pull request includes an update to the build scripts in the `package.json` file to support CommonJS module format.

Added to package.json

```
    "build:cjs": "esbuild --bundle src/index.ts --outfile=dist/popover.cjs.js --format=cjs --sourcemap",
```
