### PR TITLE
Fix setting popover to null

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -179,7 +179,11 @@ export function apply() {
         return 'manual';
       },
       set(value) {
-        this.setAttribute('popover', value);
+        if (value === null) {
+          this.removeAttribute('popover');
+        } else {
+          this.setAttribute('popover', value);
+        }
       },
     },
 


### PR DESCRIPTION
Fixes #228 

Before:

```
document.body.popover = null;
document.body.popover; // "null"
```

Now:

```
document.body.popover = null;
document.body.popover; // null
```