### PR TITLE
Clean up styles for older browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,15 +132,27 @@ some caveats which will need accommodations:
   observers or frameworks which do DOM diffing, or it may interfere with other
   code which sets `aria-expanded` on elements.
 
-- The polyfill uses `adoptedStyleSheets` to inject CSS onto the page (and each
-  Shadow DOM). If it can't use that it'll generate a `<style>` tag instead. This
-  means you may see a `<style>` tag you didn't put there, and this _may_ impact
-  mutation observers or frameworks.
+- The polyfill uses `adoptedStyleSheets` and `new CSSStyleSheet()` to inject CSS
+  onto the page (and each Shadow DOM). If it can't use that it'll generate a
+  `<style>` tag instead. This means you may see a `<style>` tag you didn't put
+  there, and this _may_ impact mutation observers or frameworks.
 
-  - For browsers which don't support `adoptedStyleSheets` on Shadow Roots, if
-    you are building a ShadowRoot by setting `.innerHTML`, you'll remove the
-    StyleSheet. Either polyfill `adoptedStyleSheets` or call
-    `injectStyles(myShadow)` to add the styles back in.
+  - For browsers which don't support `new CSSStyleSheet()`, if you are building
+    a ShadowRoot by setting `.innerHTML`, you'll remove the StyleSheet. Call
+    `injectStyles(myShadow)` to add the styles back in:
+
+    ```js
+    let supportsCSSStyleSheet = false;
+    try {
+      new CSSStyleSheet();
+      supportsCSSStyleSheet = true;
+    } catch {}
+    const myShadow = myHost.attachShadow({ mode: 'open' });
+    myShadow.innerHTML = `...`;
+    if (!supportsCSSStyleSheet) {
+      injectStyles(myShadow);
+    }
+    ```
 
   - Similarly, if you're using Declarative ShadowDOM or otherwise creating a
     shadow root without calling `attachShadow`/`attachInternals`, then the

--- a/css/base.css
+++ b/css/base.css
@@ -77,7 +77,7 @@ li ol {
 }
 
 [popover] {
-  padding: 0.5em 1em;
+  padding: var(--popover-padding, 0.5em 1em);
 }
 
 a:link,

--- a/css/base.css
+++ b/css/base.css
@@ -38,10 +38,11 @@ ul,
 ol {
   margin-inline: 2ch;
   padding-inline: unset;
+}
 
-  li & {
-    margin-block: 0;
-  }
+li ul,
+li ol {
+  margin-block: 0;
 }
 
 :focus-visible {
@@ -68,49 +69,47 @@ ol {
   padding: var(--half-shim) var(--double-gap);
   justify-content: var(--btn-content-align, center);
   justify-self: center;
+}
 
-  &:hover,
-  &:focus {
-    --button-state: var(--action);
-  }
+[data-btn]:hover,
+[data-btn]:focus {
+  --button-state: var(--action);
 }
 
 [popover] {
   padding: 0.5em 1em;
 }
 
-a {
-  &:link,
-  &:visited {
-    --underline-color--default: var(--accent-color);
-    --underline-thickness--default: 0.1em;
-    --underline-offset--default: 0.15em;
+a:link,
+a:visited {
+  --underline-color--default: var(--accent-color);
+  --underline-thickness--default: 0.1em;
+  --underline-offset--default: 0.15em;
 
-    color: var(--link, var(--action));
-    text-decoration: underline;
-    text-decoration-color: var(
-      --underline-color,
-      var(--underline-color--default)
-    );
-    text-decoration-thickness: var(
-      --underline-thickness,
-      var(--underline-thickness--default)
-    );
-    text-decoration-skip-ink: auto;
-    text-underline-offset: var(
-      --underline-offset,
-      var(--underline-offset--default)
-    );
-    transition: text-decoration-thickness 150ms ease-out;
-  }
+  color: var(--link, var(--action));
+  text-decoration: underline;
+  text-decoration-color: var(
+    --underline-color,
+    var(--underline-color--default)
+  );
+  text-decoration-thickness: var(
+    --underline-thickness,
+    var(--underline-thickness--default)
+  );
+  text-decoration-skip-ink: auto;
+  text-underline-offset: var(
+    --underline-offset,
+    var(--underline-offset--default)
+  );
+  transition: text-decoration-thickness 150ms ease-out;
+}
 
-  &:hover,
-  &:focus {
-    --underline-color: var(--active);
-    --underline-thickness: 0.2em;
+a:hover,
+a:focus {
+  --underline-color: var(--active);
+  --underline-thickness: 0.2em;
 
-    color: var(--link-focus, var(--active));
-  }
+  color: var(--link-focus, var(--active));
 }
 
 svg {

--- a/css/demo.css
+++ b/css/demo.css
@@ -255,26 +255,6 @@ a[target='_blank']::after {
   }
 }
 
-/* for browsers that don't support popovers */
-[data-popover].\:popover-open {
-  align-items: center;
-  border: 1px solid var(--border-color);
-  box-shadow: 0 3px 3px var(--shadow);
-  color: var(--popover-color, var(--text));
-  display: flex;
-  font-family: var(--sans-serif);
-  flex-wrap: wrap;
-  gap: var(--shim);
-}
-
-@media (width <=780px) {
-  [data-popover].\:popover-open {
-    inline-size: auto;
-    justify-content: center;
-    margin-inline: var(--shim);
-  }
-}
-
 [data-popover~='layered-styles'] {
   --border-color: var(--text);
   --popover-color: var(--bg);
@@ -327,5 +307,31 @@ a[target='_blank']::after {
 #fullShadowHost {
   &:focus {
     outline: none;
+  }
+}
+
+/* for browsers that don't support popovers */
+@supports not selector(:popover-open) {
+  [popover]:not(.\:popover-open) {
+    display: none;
+  }
+
+  [data-popover].\:popover-open {
+    align-items: center;
+    border: 1px solid var(--border-color);
+    box-shadow: 0 3px 3px var(--shadow);
+    color: var(--popover-color, var(--text));
+    display: flex;
+    font-family: var(--sans-serif);
+    flex-wrap: wrap;
+    gap: var(--shim);
+  }
+
+  @media (width <=780px) {
+    [data-popover].\:popover-open {
+      inline-size: auto;
+      justify-content: center;
+      margin-inline: var(--shim);
+    }
   }
 }

--- a/css/demo.css
+++ b/css/demo.css
@@ -80,17 +80,19 @@ body {
   margin-inline: var(--page-margin);
 }
 
-@media (width >=70em) {
-  .main-header {
-    align-items: var(--header-items-align, center);
-    display: flex;
-    gap: var(--double-gap);
+@supports (container: inline-size) {
+  @media (width >=70em) {
+    .main-header {
+      align-items: var(--header-items-align, center);
+      display: flex;
+      gap: var(--double-gap);
+    }
   }
-}
 
-@media (width >=1400px) {
-  .main-header {
-    --header-items-align: last baseline;
+  @media (width >=1400px) {
+    .main-header {
+      --header-items-align: last baseline;
+    }
   }
 }
 

--- a/css/demo.css
+++ b/css/demo.css
@@ -23,10 +23,10 @@ body {
 }
 
 #banner-logo [data-logo] {
-  block-size: auto;
   height: auto;
-  inline-size: 100%;
+  block-size: auto;
   width: 100%;
+  inline-size: 100%;
 }
 
 #banner-logo:link,

--- a/css/demo.css
+++ b/css/demo.css
@@ -255,10 +255,9 @@ a[target='_blank']::after {
   }
 }
 
-/* [data-popover~='layered-styles'] {
-  --border-color: var(--text);
-  --popover-color: var(--bg);
-} */
+[data-popover~='layered-styles'] {
+  --border-size: 2px;
+} 
 
 [data-popover~='nested'] {
   padding: 0;

--- a/css/demo.css
+++ b/css/demo.css
@@ -15,27 +15,27 @@ body {
   margin-block-start: var(--page-margin);
 }
 
-#banner-logo {
-  &:link,
-  &:visited {
-    align-self: start;
-    display: block;
-    grid-area: logo;
-    transition: transform 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
-    transform-origin: top center;
-    z-index: 1;
-  }
+#banner-logo:hover,
+#banner-logo:focus,
+#banner-logo:active {
+  transform: scale(1.05);
+}
 
-  &:hover,
-  &:focus,
-  &:active {
-    transform: scale(1.05);
-  }
+#banner-logo [data-logo] {
+  height: auto;
+  block-size: auto;
+  width: 100%;
+  inline-size: 100%;
+}
 
-  [data-logo] {
-    block-size: auto;
-    inline-size: 100%;
-  }
+#banner-logo:link,
+#banner-logo:visited {
+  align-self: start;
+  display: block;
+  grid-area: logo;
+  transition: transform 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  transform-origin: top center;
+  z-index: 1;
 }
 
 [data-nav] {
@@ -51,8 +51,10 @@ body {
   list-style: none;
   margin-block: 0 var(--gap);
   padding: 0;
+}
 
-  @media (width >=40em) {
+@media (width >=40em) {
+  [data-navlist] {
     --nav-placement: start;
   }
 }
@@ -60,11 +62,11 @@ body {
 [data-nav] {
   display: inline-block;
   padding: 0 var(--gap);
+}
 
-  &:not(:hover, :active, :focus, [aria-current]) {
-    --underline-color: transparent;
-    --underline-thickness: 0;
-  }
+[data-nav]:not(:hover, :active, :focus, [aria-current]) {
+  --underline-color: transparent;
+  --underline-thickness: 0;
 }
 
 [data-layout='main'] {
@@ -76,14 +78,18 @@ body {
   position: relative;
   justify-content: center;
   margin-inline: var(--page-margin);
+}
 
-  @media (width >=70em) {
+@media (width >=70em) {
+  .main-header {
     align-items: var(--header-items-align, center);
     display: flex;
     gap: var(--double-gap);
   }
+}
 
-  @media (width >=1400px) {
+@media (width >=1400px) {
+  .main-header {
     --header-items-align: last baseline;
   }
 }
@@ -93,26 +99,28 @@ body {
   grid-auto-rows: min-content;
   line-height: 0.8;
   margin-block: 0;
+}
 
-  @media (width >=56em) {
-    align-content: center;
+#title :not(.subtitle) {
+  color: var(--feature-to);
+  text-transform: uppercase;
+}
+
+@supports (background-clip: text) {
+  #title :not(.subtitle) {
+    background: var(--brand-pink);
+    background: var(--feature-gradient);
+    background-clip: text;
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+    color: transparent;
+    text-shadow: none;
   }
+}
 
-  & :not(.subtitle) {
-    color: var(--feature-to);
-    text-transform: uppercase;
-
-    @supports (background-clip: text) {
-      & {
-        background: var(--brand-pink);
-        background: var(--feature-gradient);
-        background-clip: text;
-        -webkit-box-decoration-break: clone;
-        box-decoration-break: clone;
-        color: transparent;
-        text-shadow: none;
-      }
-    }
+@media (width >=56em) {
+  #title {
+    align-content: center;
   }
 }
 
@@ -156,22 +164,22 @@ body {
   grid-template-columns: minmax(auto, 1fr) minmax(0, 57ch) minmax(auto, 1fr);
   justify-items: center;
   position: relative;
+}
 
-  &::before {
-    border-block-end: thin solid var(--border-color);
-    content: '';
-    inset: 0;
-    inset-block-end: auto;
-    position: absolute;
-  }
+.demo-section::before {
+  border-block-end: thin solid var(--border-color);
+  content: '';
+  inset: 0;
+  inset-block-end: auto;
+  position: absolute;
+}
 
-  &::after {
-    border-block-start: thin solid var(--border-color);
-    content: '';
-    position: absolute;
-    inset: 0 0 calc(var(--gap) * -2);
-    inset-block-start: auto;
-  }
+.demo-section::after {
+  border-block-start: thin solid var(--border-color);
+  content: '';
+  position: absolute;
+  inset: 0 0 calc(var(--gap) * -2);
+  inset-block-start: auto;
 }
 
 .demo-item {
@@ -187,24 +195,24 @@ body {
 [data-header] {
   grid-area: title;
   position: relative;
+}
 
-  [aria-hidden]:any-link {
-    display: inline-block;
-    filter: grayscale(var(--grayscale, 100%));
-    left: -1.25em;
-    position: absolute;
-    text-decoration: none;
-    transform: scale(var(--scale, 0.75));
-    transition: all 200ms ease-in-out;
-  }
+[data-header] [aria-hidden]:any-link {
+  display: inline-block;
+  filter: grayscale(var(--grayscale, 100%));
+  left: -1.25em;
+  position: absolute;
+  text-decoration: none;
+  transform: scale(var(--scale, 0.75));
+  transition: all 200ms ease-in-out;
+}
 
-  [aria-hidden]:hover,
-  [aria-hidden]:focus,
-  [aria-hidden]:active {
-    --grayscale: 0;
-    --scale: 1;
-    --outline-offset: 0.025em;
-  }
+[data-header] [aria-hidden]:hover,
+[data-header] [aria-hidden]:focus,
+[data-header] [aria-hidden]:active {
+  --grayscale: 0;
+  --scale: 1;
+  --outline-offset: 0.025em;
 }
 
 a[target='_blank']::after {
@@ -235,8 +243,10 @@ a[target='_blank']::after {
   font-family: var(--sans-serif);
   flex-wrap: wrap;
   gap: var(--shim);
+}
 
-  @media (width <=780px) {
+@media (width <=780px) {
+  [data-popover]:popover-open {
     inline-size: auto;
     justify-content: center;
     margin-inline: var(--shim);
@@ -253,8 +263,10 @@ a[target='_blank']::after {
   font-family: var(--sans-serif);
   flex-wrap: wrap;
   gap: var(--shim);
+}
 
-  @media (width <=780px) {
+@media (width <=780px) {
+  [data-popover].\:popover-open {
     inline-size: auto;
     justify-content: center;
     margin-inline: var(--shim);
@@ -272,10 +284,10 @@ a[target='_blank']::after {
 
 [data-popover~='manual'] {
   inset-block-end: var(--popover-offset);
+}
 
-  &:nth-of-type(2) {
-    inset-block-end: calc(var(--popover-offset) * 2);
-  }
+[data-popover~='manual']:nth-of-type(2) {
+  inset-block-end: calc(var(--popover-offset) * 2);
 }
 
 [data-popover~='inner-shadowed'] {
@@ -287,12 +299,12 @@ a[target='_blank']::after {
   --button-color: var(--text);
   --btn-content-align: start;
   --btn-inline-size: 100%;
+}
 
-  &:hover,
-  &:focus {
-    --button-color: var(--bg);
-    outline-color: transparent;
-  }
+[data-btn~='menu-item']:hover,
+[data-btn~='menu-item']:focus {
+  --button-color: var(--bg);
+  outline-color: transparent;
 }
 
 .site-footer {

--- a/css/demo.css
+++ b/css/demo.css
@@ -257,7 +257,7 @@ a[target='_blank']::after {
 
 [data-popover~='layered-styles'] {
   --border-size: 2px;
-} 
+}
 
 [data-popover~='nested'] {
   padding: 0;

--- a/css/demo.css
+++ b/css/demo.css
@@ -260,7 +260,7 @@ a[target='_blank']::after {
 }
 
 [data-popover~='nested'] {
-  padding: 0;
+  --popover-padding: 0;
 }
 
 [data-popover~='manual'] {

--- a/css/demo.css
+++ b/css/demo.css
@@ -1,5 +1,6 @@
 body {
   --page-margin: var(--double-gap);
+  --page-columns: minmax(auto, 1fr) minmax(0, 57ch) minmax(auto, 1fr);
   display: grid;
   grid-template: 'site-header' auto 'main' 1fr 'footer' auto / 100%;
 }
@@ -75,9 +76,14 @@ body {
 
 .main-header {
   container: main-header / inline-size;
+  display: grid;
+  grid-template-columns: var(--page-columns);
   position: relative;
-  justify-content: center;
   margin-inline: var(--page-margin);
+}
+
+.main-header > * {
+  grid-column: 2;
 }
 
 @supports (container: inline-size) {
@@ -165,6 +171,7 @@ body {
   gap: var(--gap);
   grid-template-columns: minmax(auto, 1fr) minmax(0, 57ch) minmax(auto, 1fr);
   justify-items: center;
+  padding-inline: var(--page-margin);
   position: relative;
 }
 

--- a/css/demo.css
+++ b/css/demo.css
@@ -1,6 +1,6 @@
 body {
-  --page-margin: var(--double-gap);
   --page-columns: minmax(auto, 1fr) minmax(0, 57ch) minmax(auto, 1fr);
+  --page-margin: var(--double-gap);
   display: grid;
   grid-template: 'site-header' auto 'main' 1fr 'footer' auto / 100%;
 }
@@ -23,10 +23,10 @@ body {
 }
 
 #banner-logo [data-logo] {
-  height: auto;
   block-size: auto;
-  width: 100%;
+  height: auto;
   inline-size: 100%;
+  width: 100%;
 }
 
 #banner-logo:link,
@@ -34,8 +34,8 @@ body {
   align-self: start;
   display: block;
   grid-area: logo;
-  transition: transform 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
   transform-origin: top center;
+  transition: transform 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
   z-index: 1;
 }
 
@@ -78,8 +78,8 @@ body {
   container: main-header / inline-size;
   display: grid;
   grid-template-columns: var(--page-columns);
-  position: relative;
   margin-inline: var(--page-margin);
+  position: relative;
 }
 
 .main-header > * {
@@ -186,9 +186,9 @@ body {
 .demo-section::after {
   border-block-start: thin solid var(--border-color);
   content: '';
-  position: absolute;
   inset: 0 0 calc(var(--gap) * -2);
   inset-block-start: auto;
+  position: absolute;
 }
 
 .demo-item {
@@ -220,8 +220,8 @@ body {
 [data-header] [aria-hidden]:focus,
 [data-header] [aria-hidden]:active {
   --grayscale: 0;
-  --scale: 1;
   --outline-offset: 0.025em;
+  --scale: 1;
 }
 
 a[target='_blank']::after {
@@ -249,8 +249,8 @@ a[target='_blank']::after {
   box-shadow: 0 3px 3px var(--shadow);
   color: var(--popover-color, var(--text));
   display: flex;
-  font-family: var(--sans-serif);
   flex-wrap: wrap;
+  font-family: var(--sans-serif);
   gap: var(--shim);
 }
 
@@ -299,8 +299,8 @@ a[target='_blank']::after {
   grid-area: footer;
   margin-block-start: var(--spacer);
   margin-inline: var(--page-margin);
-  position: relative;
   padding-block-end: var(--double-gap);
+  position: relative;
 }
 
 .menu-list {
@@ -328,8 +328,8 @@ a[target='_blank']::after {
     box-shadow: 0 3px 3px var(--shadow);
     color: var(--popover-color, var(--text));
     display: flex;
-    font-family: var(--sans-serif);
     flex-wrap: wrap;
+    font-family: var(--sans-serif);
     gap: var(--shim);
   }
 

--- a/css/demo.css
+++ b/css/demo.css
@@ -238,7 +238,7 @@ a[target='_blank']::after {
 
 [data-popover]:popover-open {
   align-items: center;
-  border: 1px solid var(--border-color);
+  border: var(--border-size) solid var(--border-color);
   box-shadow: 0 3px 3px var(--shadow);
   color: var(--popover-color, var(--text));
   display: flex;
@@ -255,10 +255,10 @@ a[target='_blank']::after {
   }
 }
 
-[data-popover~='layered-styles'] {
+/* [data-popover~='layered-styles'] {
   --border-color: var(--text);
   --popover-color: var(--bg);
-}
+} */
 
 [data-popover~='nested'] {
   padding: 0;

--- a/css/props.css
+++ b/css/props.css
@@ -83,6 +83,5 @@ html {
     --step-9: clamp(5.8048rem, 4.5844rem + 6.1017cqi, 19.3132rem);
     --step-10: clamp(6.9657rem, 5.3393rem + 8.1319cqi, 19.6415rem);
     --gap: clamp(12px, 2cqmin, 24px);
-    --spacer: clamp(1.5rlh, 10vw, 5rlh);
   }
 }

--- a/css/props.css
+++ b/css/props.css
@@ -32,6 +32,7 @@ html {
   --xlarge: var(--step-2);
   --h1: var(--xlarge);
   --title-size: var(--step-6);
+  --border-size: 1px;
 
   --gap: 0.75rem;
   --double-gap: calc(var(--gap) * 2);

--- a/css/props.css
+++ b/css/props.css
@@ -13,16 +13,18 @@ html {
   --code: var(--wf-code, var(--os-code, ui-monospace)), monospace, serif;
 
   /* scale */
-  --step-n1: clamp(0.9375rem, 0.8638rem + 0.3685cqi, 1.1494rem);
-  --step-0: clamp(1.125rem, 0.9511rem + 0.8696cqi, 1.625rem);
-  --step-1: clamp(1.35rem, 1.0204rem + 1.6478cqi, 2.2975rem);
-  --step-2: clamp(1.62rem, 1.0535rem + 2.8326cqi, 3.2488rem);
-  --step-3: clamp(1.9438rem, 1.0218rem + 4.6098cqi, 4.5944rem);
-  --step-6: clamp(3.3592rem, 2.8691rem + 2.4507cqi, 4.7684rem);
-  --step-7: clamp(4.0311rem, 3.36rem + 3.3555cqi, 5.9605rem);
-  --step-8: clamp(4.8373rem, 3.9283rem + 4.5448cqi, 17.4506rem);
-  --step-9: clamp(5.8048rem, 4.5844rem + 6.1017cqi, 19.3132rem);
-  --step-10: clamp(6.9657rem, 5.3393rem + 8.1319cqi, 19.6415rem);
+  --step-n1: clamp(0.9375rem, 0.814rem + 0.6173vw, 1.3542rem);
+  --step-0: clamp(1.125rem, 0.9769rem + 0.7407vw, 1.625rem);
+  --step-1: clamp(1.35rem, 1.1722rem + 0.8889vw, 1.95rem);
+  --step-2: clamp(1.62rem, 1.4067rem + 1.0667vw, 2.34rem);
+  --step-3: clamp(1.944rem, 1.688rem + 1.28vw, 2.808rem);
+  --step-4: clamp(2.3328rem, 2.0256rem + 1.536vw, 3.3696rem);
+  --step-5: clamp(2.7994rem, 2.4307rem + 1.8432vw, 4.0435rem);
+  --step-6: clamp(3.3592rem, 2.9169rem + 2.2118vw, 4.8522rem);
+  --step-7: clamp(4.0311rem, 3.5002rem + 2.6542vw, 5.8227rem);
+  --step-8: clamp(4.8373rem, 4.2003rem + 3.185vw, 6.9872rem);
+  --step-9: clamp(5.8048rem, 5.0403rem + 3.8221vw, 8.3846rem);
+  --step-10: clamp(6.9657rem, 6.0484rem + 4.5865vw, 10.0616rem);
 
   --small: var(--step-n1);
   --normal: var(--step-0);
@@ -31,12 +33,12 @@ html {
   --h1: var(--xlarge);
   --title-size: var(--step-6);
 
-  --gap: clamp(12px, 2cqmin, 24px);
+  --gap: 0.75rem;
   --double-gap: calc(var(--gap) * 2);
   --shim: calc(var(--gap) / 2);
   --half-shim: calc(var(--shim) / 2);
   --quarter-shim: calc(var(--shim) / 4);
-  --spacer: clamp(1.5rlh, 10vw, 5rlh);
+  --spacer: calc(var(--double-gap) + 3vw);
 
   /* background colors */
   --bg: hsl(200 12% 95.098%);
@@ -65,4 +67,21 @@ html {
   --ccs-prime--fg3: hsl(195deg 53% 27%);
   --ccs-special--fg3: hsl(24deg 53% 27%);
   --ccs-accent--fg2: hsl(330deg 60% 35%);
+}
+
+@supports (font-size: 2cqi) {
+  html {
+    --step-n1: clamp(0.9375rem, 0.8638rem + 0.3685cqi, 1.1494rem);
+    --step-0: clamp(1.125rem, 0.9511rem + 0.8696cqi, 1.625rem);
+    --step-1: clamp(1.35rem, 1.0204rem + 1.6478cqi, 2.2975rem);
+    --step-2: clamp(1.62rem, 1.0535rem + 2.8326cqi, 3.2488rem);
+    --step-3: clamp(1.9438rem, 1.0218rem + 4.6098cqi, 4.5944rem);
+    --step-6: clamp(3.3592rem, 2.8691rem + 2.4507cqi, 4.7684rem);
+    --step-7: clamp(4.0311rem, 3.36rem + 3.3555cqi, 5.9605rem);
+    --step-8: clamp(4.8373rem, 3.9283rem + 4.5448cqi, 17.4506rem);
+    --step-9: clamp(5.8048rem, 4.5844rem + 6.1017cqi, 19.3132rem);
+    --step-10: clamp(6.9657rem, 5.3393rem + 8.1319cqi, 19.6415rem);
+    --gap: clamp(12px, 2cqmin, 24px);
+    --spacer: clamp(1.5rlh, 10vw, 5rlh);
+  }
 }

--- a/index.html
+++ b/index.html
@@ -691,9 +691,9 @@ menuShadowRoot.innerHTML = `
             });
             shadowHostWithSlotRoot.innerHTML = `
               <style>
-                @import url('/css/demo.css') layer(demo);
-                @import url('/css/fonts.css') layer(initial);
-                @import url('/css/base.css') layer(default);
+                @import url('/css/demo.css');
+                @import url('/css/fonts.css');
+                @import url('/css/base.css');
               </style>
               <div id="shadowedPopoverWithSlot" popover data-popover><slot></slot></div>
               <div class="button-group">

--- a/index.html
+++ b/index.html
@@ -12,15 +12,13 @@
       crossorigin
     />
     <style>
-      @layer reset, initial, popover-polyfill, default, demo;
-
-      @import url('/css/reset.css') layer(reset);
-      @import url('/css/demo.css') layer(demo);
-      @import url('/css/prism.css') layer(initial);
-      @import url('/css/fonts.css') layer(initial);
-      @import url('/css/base.css') layer(default);
-      @import url('/css/props.css') layer(initial);
-      @import url('/css/code.css') layer(default);
+      @import url('/css/reset.css');
+      @import url('/css/demo.css');
+      @import url('/css/prism.css');
+      @import url('/css/fonts.css');
+      @import url('/css/base.css');
+      @import url('/css/props.css');
+      @import url('/css/code.css');
     </style>
     <style>
       @layer popover-polyfill;
@@ -432,11 +430,9 @@
             });
             crossTreeShadowRoot.innerHTML = `
               <style>
-                @layer reset, initial, popover-polyfill, default, demo;
-
-                @import url('/css/demo.css') layer(demo);
-                @import url('/css/fonts.css') layer(initial);
-                @import url('/css/base.css') layer(default);
+                @import url('/css/demo.css');
+                @import url('/css/fonts.css');
+                @import url('/css/base.css');
               </style>
               <div id="crossTreePopover" popover data-popover>Shadowed Popover</div>`;
             document.getElementById('crossTreeToggle').popoverTargetElement =
@@ -549,11 +545,9 @@ shadowRoot.innerHTML = `&lt;span&gt;Toggle Shadow Invoked Popover&lt;/span&gt;`;
             const menuShadowRoot = menuHost.attachShadow({ mode: 'open' });
             menuShadowRoot.innerHTML = `
               <style>
-                @layer reset, initial, popover-polyfill, default, demo;
-
-                @import url('/css/demo.css') layer(demo);
-                @import url('/css/fonts.css') layer(initial);
-                @import url('/css/base.css') layer(default);
+                @import url('/css/demo.css');
+                @import url('/css/fonts.css');
+                @import url('/css/base.css');
               </style>
 
               <button popovertarget="shadowedMenuInner" data-btn>
@@ -646,11 +640,9 @@ menuShadowRoot.innerHTML = `
             });
             fullShadowRoot.innerHTML = `
               <style>
-                @layer reset, initial, popover-polyfill, default, demo;
-
-                @import url('/css/demo.css') layer(demo);
-                @import url('/css/fonts.css') layer(initial);
-                @import url('/css/base.css') layer(default);
+                @import url('/css/demo.css');
+                @import url('/css/fonts.css');
+                @import url('/css/base.css');
               </style>
               <div id="shadowedPopover" popover data-popover>Shadowed Popover</div>
               <div>
@@ -699,8 +691,6 @@ menuShadowRoot.innerHTML = `
             });
             shadowHostWithSlotRoot.innerHTML = `
               <style>
-                @layer reset, initial, popover-polyfill, default, demo;
-
                 @import url('/css/demo.css') layer(demo);
                 @import url('/css/fonts.css') layer(initial);
                 @import url('/css/base.css') layer(default);

--- a/index.html
+++ b/index.html
@@ -44,6 +44,17 @@
         note.innerText =
           'This browser does not support the Popover API natively, so the polyfill has been applied.';
       }
+
+      // If `new CSSStyleSheet()` isn't supported, then shadow roots that have
+      // content set using `.innerHTML(...)` will override the default injected
+      // stylesheets, and they'll need to be manually re-injected
+      window.supportsCSSStyleSheet = false;
+      try {
+        new CSSStyleSheet();
+        window.supportsCSSStyleSheet = true;
+      } catch {
+        // no support
+      }
     </script>
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <script src="https://unpkg.com/prismjs@v1.x/components/prism-core.min.js"></script>
@@ -179,7 +190,6 @@
           Single Action Popover. This popover has an
           <a href="#" autofocus>autofocus link.</a>
         </div>
-        <div id="crossTreeHost"></div>
         <div id="menuPopover" data-popover="nested" popover>
           <ul class="menu-list">
             <li><button data-btn="menu-item">Item 1</button></li>
@@ -420,10 +430,13 @@
               >.</em
             >
           </p>
+          <div id="crossTreeHost"></div>
           <button id="crossTreeToggle" data-btn>
             Toggle Cross Tree Popover
           </button>
           <script type="module">
+            import { injectStyles } from './dist/popover-fn.js';
+
             const crossTreeHost = document.getElementById('crossTreeHost');
             const crossTreeShadowRoot = crossTreeHost.attachShadow({
               mode: 'open',
@@ -435,6 +448,9 @@
                 @import url('/css/base.css');
               </style>
               <div id="crossTreePopover" popover data-popover>Shadowed Popover</div>`;
+            if (!window.supportsCSSStyleSheet) {
+              injectStyles(crossTreeShadowRoot);
+            }
             document.getElementById('crossTreeToggle').popoverTargetElement =
               crossTreeShadowRoot.getElementById('crossTreePopover');
           </script>
@@ -541,6 +557,8 @@ shadowRoot.innerHTML = `&lt;span&gt;Toggle Shadow Invoked Popover&lt;/span&gt;`;
             Toggle Menu with Shadowed Popover
           </button>
           <script type="module">
+            import { injectStyles } from './dist/popover-fn.js';
+
             const menuHost = document.getElementById('menuHost');
             const menuShadowRoot = menuHost.attachShadow({ mode: 'open' });
             menuShadowRoot.innerHTML = `
@@ -556,6 +574,9 @@ shadowRoot.innerHTML = `&lt;span&gt;Toggle Shadow Invoked Popover&lt;/span&gt;`;
               <div id="shadowedMenuInner" data-popover="inner-shadowed" popover>
                 Inner Shadowed Popover
               </div>`;
+            if (!window.supportsCSSStyleSheet) {
+              injectStyles(menuShadowRoot);
+            }
           </script>
           <pre><code class="language-html"
 >&lt;!-- Light DOM --&gt;
@@ -634,6 +655,8 @@ menuShadowRoot.innerHTML = `
           </p>
           <div id="fullShadowHost"></div>
           <script type="module">
+            import { injectStyles } from './dist/popover-fn.js';
+
             const fullShadowHost = document.getElementById('fullShadowHost');
             const fullShadowRoot = fullShadowHost.attachShadow({
               mode: 'open',
@@ -656,6 +679,9 @@ menuShadowRoot.innerHTML = `
                   Toggle Shadowed Nested Popover
                 </button>
               </div>`;
+            if (!window.supportsCSSStyleSheet) {
+              injectStyles(fullShadowRoot);
+            }
           </script>
           <pre><code class="language-html"
 >&lt;!-- Shadow DOM --&gt;
@@ -684,6 +710,8 @@ menuShadowRoot.innerHTML = `
             <div><span>I’m a slotted element</span></div>
           </div>
           <script type="module">
+            import { injectStyles } from './dist/popover-fn.js';
+
             const shadowHostWithSlot =
               document.getElementById('shadowHostWithSlot');
             const shadowHostWithSlotRoot = shadowHostWithSlot.attachShadow({
@@ -701,6 +729,9 @@ menuShadowRoot.innerHTML = `
                   Toggle Shadowed Popover
                 </button>
               </div>`;
+            if (!window.supportsCSSStyleSheet) {
+              injectStyles(shadowHostWithSlotRoot);
+            }
           </script>
           <pre><code class="language-html"
 >&lt;!-- Light DOM --&gt;

--- a/index.html
+++ b/index.html
@@ -26,7 +26,6 @@
       @layer consumer {
         [data-popover~='layered-styles'] {
           --border-color: #d00d1e;
-          --border-size: 2px;
         }
       }
     </style>
@@ -611,7 +610,7 @@ menuShadowRoot.innerHTML = `
 
 &lt;div id="layeredStylesPopover" data-popover="layered-styles" popover&gt;
   Popover with Layered Styles
-  (should be red if browser has &lt;code&gt;@layer&lt;/code&gt; support)
+  (border should be red if browser has &lt;code&gt;@layer&lt;/code&gt; support)
 &lt;/div&gt;</code>
 
 <code class="language-css"

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 
       @layer consumer {
         [data-popover~='layered-styles'] {
-          background-color: #d00d1e;
+          --border-color: #d00d1e;
+          --border-size: 2px;
         }
       }
     </style>
@@ -221,7 +222,7 @@
           <div id="menuHost"></div>
         </div>
         <div id="layeredStylesPopover" data-popover="layered-styles" popover>
-          Popover with Layered Styles (should be red if browser has
+          Popover with Layered Styles (border should be red if browser has
           <code>@layer</code> support)
         </div>
 
@@ -619,7 +620,7 @@ menuShadowRoot.innerHTML = `
 
 @layer consumer {
   [data-popover~='layered-styles'] {
-    background-color: #d00d1e;
+    --border-color: #d00d1e;
   }
 }</code></pre>
         </section>

--- a/tests/edge-cases.spec.ts
+++ b/tests/edge-cases.spec.ts
@@ -25,5 +25,5 @@ test('styles in layers are winning over polyfilled styles', async ({
   page,
 }) => {
   const popover = (await page.locator('#layeredStylesPopover')).nth(0);
-  await expect(popover).toHaveCSS('--border-color', 'rgb(208, 13, 30)');
+  await expect(popover).toHaveCSS('--border-color', '#d00d1e');
 });

--- a/tests/edge-cases.spec.ts
+++ b/tests/edge-cases.spec.ts
@@ -25,5 +25,5 @@ test('styles in layers are winning over polyfilled styles', async ({
   page,
 }) => {
   const popover = (await page.locator('#layeredStylesPopover')).nth(0);
-  await expect(popover).toHaveCSS('border-color', 'rgb(208, 13, 30)');
+  await expect(popover).toHaveCSS('border-left-color', 'rgb(208, 13, 30)');
 });

--- a/tests/edge-cases.spec.ts
+++ b/tests/edge-cases.spec.ts
@@ -25,5 +25,5 @@ test('styles in layers are winning over polyfilled styles', async ({
   page,
 }) => {
   const popover = (await page.locator('#layeredStylesPopover')).nth(0);
-  await expect(popover).toHaveCSS('border-left-color', 'rgb(208, 13, 30)');
+  await expect(popover).toHaveCSS('--border-color', 'rgb(208, 13, 30)');
 });

--- a/tests/edge-cases.spec.ts
+++ b/tests/edge-cases.spec.ts
@@ -25,5 +25,5 @@ test('styles in layers are winning over polyfilled styles', async ({
   page,
 }) => {
   const popover = (await page.locator('#layeredStylesPopover')).nth(0);
-  await expect(popover).toHaveCSS('background-color', 'rgb(208, 13, 30)');
+  await expect(popover).toHaveCSS('border-color', 'rgb(208, 13, 30)');
 });


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&CHANGE_ME)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->

## Related Issue(s)
Fixes #205 



## Steps to test/reproduce
-  On Sauce Labs, view the demo page in Safari 15 and 16 (Ventura OS) or versions of other browsers before they implemented cascade layers. 
- Compare the the deploy preview here to the live site. In the latest versions of browsers, everything should be the same (except for the updated `@layers` popover example). 

![image](https://github.com/user-attachments/assets/5664180f-9c80-40af-a7ec-a102a817e24a)


_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._

