### PR TITLE
Support for popover=hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,18 +39,18 @@
       const note = document.getElementById('browser-support');
 
       if (isSupported() && isHintSupported()) {
-        console.log('native `popover` support detected, no polyfill used');
+        console.log('native `popover` support detected; no polyfill used');
         note.innerText =
           'This browser supports the Popover API natively, so the polyfill has not been applied.';
       } else if (isSupported()) {
         console.log(
-          'native `popover` support detected, but hint support was not found. No polyfill used',
+          'native `popover` support detected, but `popover=hint` support was not found; no polyfill used',
         );
         note.innerText =
-          'This browser supports the Popover API natively, but not "hint".';
+          'This browser supports the Popover API natively, but not "popover=hint". The polyfill has not been applied.';
       } else {
         apply();
-        console.log('polyfill applied');
+        console.log('`popover` polyfill applied');
         note.innerText =
           'This browser does not support the Popover API natively, so the polyfill has been applied.';
       }
@@ -68,9 +68,6 @@
       document.querySelectorAll('[data-hover-target]').forEach((el) => {
         const target = document.getElementById(el.dataset.hoverTarget);
         el.addEventListener('mouseover', () => {
-          target.togglePopover();
-        });
-        el.addEventListener('focus', () => {
           target.togglePopover();
         });
       });
@@ -194,7 +191,15 @@
       </div>
       <div id="popovers">
         <div id="defaultPopover" data-popover popover>Default Popover</div>
-        <div id="autoPopover" data-popover popover="auto">Auto Popover</div>
+        <div id="autoPopover" data-popover popover="auto">
+          Auto Popover
+          <button data-hover-target="hintPopover3" data-btn>
+            Hover to toggle Nested hint popover
+          </button>
+          <div id="hintPopover3" popover="hint" style="inset-block-start: 15em">
+            Nested hint popover
+          </div>
+        </div>
         <div id="manualPopover" data-popover="manual" popover="manual">
           Manual Popover
         </div>
@@ -328,23 +333,36 @@
           </div>
           <p class="note">Hint popovers only dismiss other hint popovers.</p>
           <pre><code class="language-html"
->&lt;button data-hover-target="hintPopover" data-btn&gt;
+>&lt;button data-hover-target="hintPopover"&gt;
   Hover to toggle Hint Popover
 &lt;/button&gt;
-&lt;button data-hover-target="hintPopover2" data-btn&gt;
+&lt;button data-hover-target="hintPopover2"&gt;
   Hover to toggle Hint Popover 2
 &lt;/button&gt;
-&lt;button popovertarget="autoPopover" data-btn&gt;
+&lt;button popovertarget="autoPopover"&gt;
   Show Auto Popover
-&lt;/button&gt;</code></pre>
+&lt;/button&gt;
+
+&lt;div id="hintPopover" popover="hint"&gt;
+  Popover ("hint")
+&lt;/div&gt;
+&lt;div id="hintPopover2" popover="hint"&gt;
+  Popover ("hint 2")
+&lt;/div&gt;
+&lt;div id="autoPopover" popover="auto"&gt;
+  Auto Popover
+  &lt;button data-hover-target="hintPopover3"&gt;
+    Hover to toggle Nested hint popover
+  &lt;/button&gt;
+  &lt;div id="hintPopover3" popover="hint"&gt;
+    Nested hint popover
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
           <pre><code class="language-js">// JavaScript
 document.querySelectorAll('[data-hover-target]').forEach((el) => {
   const target = document.getElementById(el.dataset.hoverTarget);
   el.addEventListener('mouseover', () => {
-    target.togglePopover({source: el});
-  });
-  el.addEventListener('focus', () => {
-    target.togglePopover({source: el});
+    target.togglePopover({ source: el });
   });
 });</code></pre>
         </section>

--- a/index.html
+++ b/index.html
@@ -191,7 +191,12 @@
       </div>
       <div id="popovers">
         <div id="defaultPopover" data-popover popover>Default Popover</div>
-        <div id="autoPopover" data-popover popover="auto">
+        <div
+          id="autoPopover"
+          data-popover
+          popover="auto"
+          style="margin: 0; inset-block-start: 15em"
+        >
           Auto Popover
           <button data-hover-target="hintPopover3" data-btn>
             Hover to toggle Nested hint popover
@@ -203,10 +208,18 @@
         <div id="manualPopover" data-popover="manual" popover="manual">
           Manual Popover
         </div>
-        <div id="hintPopover" popover="hint" style="inset-block-start: 5em">
+        <div
+          id="hintPopover"
+          popover="hint"
+          style="inset-block-start: 5em; margin: 0"
+        >
           Popover ("hint")
         </div>
-        <div id="hintPopover2" popover="hint" style="inset-block-start: 10em">
+        <div
+          id="hintPopover2"
+          popover="hint"
+          style="inset-block-start: 10em; margin: 0"
+        >
           Popover ("hint 2")
         </div>
         <div id="emptyStatePopover" data-popover popover="">
@@ -322,7 +335,7 @@
           </h2>
           <div style="display: grid; gap: 1em">
             <button data-hover-target="hintPopover" data-btn>
-              Hover to toggle Hint Popover
+              Hover to toggle Hint Popover 1
             </button>
             <button data-hover-target="hintPopover2" data-btn>
               Hover to toggle Hint Popover 2

--- a/index.html
+++ b/index.html
@@ -30,14 +30,24 @@
       }
     </style>
     <script type="module">
-      import { apply, isSupported } from './dist/popover-fn.js';
+      import {
+        apply,
+        isSupported,
+        isHintSupported,
+      } from './dist/popover-fn.js';
 
       const note = document.getElementById('browser-support');
 
-      if (isSupported()) {
+      if (isSupported() && isHintSupported()) {
         console.log('native `popover` support detected, no polyfill used');
         note.innerText =
           'This browser supports the Popover API natively, so the polyfill has not been applied.';
+      } else if (isSupported()) {
+        console.log(
+          'native `popover` support detected, but hint support was not found. No polyfill used',
+        );
+        note.innerText =
+          'This browser supports the Popover API natively, but not "hint".';
       } else {
         apply();
         console.log('polyfill applied');
@@ -55,6 +65,15 @@
       } catch {
         // no support
       }
+      document.querySelectorAll('[data-hover-target]').forEach((el) => {
+        const target = document.getElementById(el.dataset.hoverTarget);
+        el.addEventListener('mouseover', () => {
+          target.togglePopover({ source: el });
+        });
+        el.addEventListener('focus', () => {
+          target.togglePopover({ source: el });
+        });
+      });
     </script>
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <script src="https://unpkg.com/prismjs@v1.x/components/prism-core.min.js"></script>
@@ -175,10 +194,16 @@
       </div>
       <div id="popovers">
         <div id="defaultPopover" data-popover popover>Default Popover</div>
+        <div id="autoPopover" data-popover popover="auto">Auto Popover</div>
         <div id="manualPopover" data-popover="manual" popover="manual">
           Manual Popover
         </div>
-        <div id="hintPopover" popover="hint">Popover ("hint")</div>
+        <div id="hintPopover" popover="hint" style="inset-block-start: 5em">
+          Popover ("hint")
+        </div>
+        <div id="hintPopover2" popover="hint" style="inset-block-start: 10em">
+          Popover ("hint 2")
+        </div>
         <div id="emptyStatePopover" data-popover popover="">
           Empty State Popover
         </div>
@@ -284,6 +309,44 @@
 &lt;/button&gt;
 
 &lt;div id="manualPopover" popover="manual"&gt;Manual Popover&lt;/div&gt;</code></pre>
+        </section>
+        <section id="popover-hint" class="demo-item">
+          <h2 data-header>
+            <a href="#popover-hint" aria-hidden="true">🔗</a>
+            Popover hint
+          </h2>
+          <div style="display: grid; gap: 1em">
+            <button data-hover-target="hintPopover" data-btn>
+              Hover to toggle Hint Popover
+            </button>
+            <button data-hover-target="hintPopover2" data-btn>
+              Hover to toggle Hint Popover 2
+            </button>
+            <button popovertarget="autoPopover" data-btn>
+              Show Auto Popover
+            </button>
+          </div>
+          <p class="note">Hint popovers only dismiss other hint popovers.</p>
+          <pre><code class="language-html"
+>&lt;button data-hover-target="hintPopover" data-btn&gt;
+  Hover to toggle Hint Popover
+&lt;/button&gt;
+&lt;button data-hover-target="hintPopover2" data-btn&gt;
+  Hover to toggle Hint Popover 2
+&lt;/button&gt;
+&lt;button popovertarget="autoPopover" data-btn&gt;
+  Show Auto Popover
+&lt;/button&gt;</code></pre>
+          <pre><code class="language-js">// JavaScript
+document.querySelectorAll('[data-hover-target]').forEach((el) => {
+  const target = document.getElementById(el.dataset.hoverTarget);
+  el.addEventListener('mouseover', () => {
+    target.togglePopover({source: el});
+  });
+  el.addEventListener('focus', () => {
+    target.togglePopover({source: el});
+  });
+});</code></pre>
         </section>
         <section id="popover-dialog" class="demo-item">
           <h2 data-header>

--- a/index.html
+++ b/index.html
@@ -68,10 +68,10 @@
       document.querySelectorAll('[data-hover-target]').forEach((el) => {
         const target = document.getElementById(el.dataset.hoverTarget);
         el.addEventListener('mouseover', () => {
-          target.togglePopover({ source: el });
+          target.togglePopover();
         });
         el.addEventListener('focus', () => {
-          target.togglePopover({ source: el });
+          target.togglePopover();
         });
       });
     </script>

--- a/index.html
+++ b/index.html
@@ -178,6 +178,7 @@
         <div id="manualPopover" data-popover="manual" popover="manual">
           Manual Popover
         </div>
+        <div id="hintPopover" popover="hint">Popover ("hint")</div>
         <div id="emptyStatePopover" data-popover popover="">
           Empty State Popover
         </div>
@@ -237,9 +238,6 @@
 
         <div id="test-popover-invalid" popover="invalid">
           Invalid Popover ("invalid")
-        </div>
-        <div id="test-popover-invalid-hint" popover="hint">
-          Invalid Popover ("hint")
         </div>
         <div id="test-popover" popover="auto">Test Popover 1 (auto)</div>
         <div id="test-popover-2" popover="auto">Test Popover 2 (auto)</div>

--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -28,6 +28,10 @@ const combinedPopoverListForDocument = (
   return new Set([...autoPopovers, ...hintPopovers]);
 };
 
+function lastSetElement(set: Set<HTMLElement>) {
+  return [...set].pop() as HTMLElement;
+}
+
 // https://html.spec.whatwg.org/#popover-target-attribute-activation-behavior
 export function popoverTargetAttributeActivationBehavior(
   element: HTMLButtonElement | HTMLInputElement,
@@ -415,7 +419,7 @@ export function hidePopover(
   }
   const autoList = autoPopoverList.get(document) || new Set();
   const autoPopoverListContainsElement =
-    autoList.has(element) && [...autoList].pop() === element;
+    autoList.has(element) && lastSetElement(autoList) === element;
   setInvokerAriaExpanded(popoverInvoker.get(element), false);
   popoverInvoker.delete(element);
   if (fireEvents) {
@@ -425,7 +429,10 @@ export function hidePopover(
         newState: 'closed',
       }),
     );
-    if (autoPopoverListContainsElement && [...autoList].pop() !== element) {
+    if (
+      autoPopoverListContainsElement &&
+      lastSetElement(autoList) !== element
+    ) {
       hideAllPopoversUntil(element, focusPreviousElement, fireEvents);
     }
     if (!checkPopoverValidity(element, true)) {
@@ -498,13 +505,9 @@ function hidePopoverStackUntil(
     }
     if (!lastToHide) return;
     while (getPopoverVisibilityState(lastToHide) === 'showing' && set.size) {
-      hidePopover(
-        [...set].pop() as HTMLElement,
-        focusPreviousElement,
-        fireEvents,
-      );
+      hidePopover(lastSetElement(set), focusPreviousElement, fireEvents);
     }
-    if (set.has(endpoint as HTMLElement) && [...set].pop() !== endpoint) {
+    if (set.has(endpoint as HTMLElement) && lastSetElement(set) !== endpoint) {
       repeatingHide = true;
     }
     if (repeatingHide) {

--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -10,7 +10,7 @@ const topLayerElements = new WeakMap<Document, Set<HTMLElement>>();
 const autoPopoverList = new WeakMap<Document, Set<HTMLElement>>();
 const hintPopoverList = new WeakMap<Document, Set<HTMLElement>>();
 export const visibilityState = new WeakMap<HTMLElement, 'hidden' | 'showing'>();
-const openInPopoverMode = new WeakMap<HTMLElement, 'auto' | 'hint'>();
+
 function getPopoverVisibilityState(popover: HTMLElement): 'hidden' | 'showing' {
   return visibilityState.get(popover) || 'hidden';
 }
@@ -294,7 +294,7 @@ export function showPopover(element: HTMLElement) {
   }
   let shouldRestoreFocus = false;
   const originalType = element.getAttribute('popover');
-  let stackToAppendTo = originalType;
+
   const autoAncestor = topMostPopoverAncestor(
     element,
     autoPopoverList.get(document) || new Set(),
@@ -325,7 +325,6 @@ export function showPopover(element: HTMLElement) {
       );
       if (autoAncestor) {
         hideAllPopoversUntil(autoAncestor, shouldRestoreFocus, true);
-        stackToAppendTo = 'auto';
       }
     }
   }
@@ -338,18 +337,6 @@ export function showPopover(element: HTMLElement) {
 
   if (!topMostAutoOrHintPopover(document)) {
     shouldRestoreFocus = true;
-  }
-
-  if (
-    stackToAppendTo === 'auto' &&
-    !autoPopoverList.get(document)?.has(element)
-  ) {
-    openInPopoverMode.set(element, 'auto');
-  } else if (
-    stackToAppendTo === 'hint' &&
-    !hintPopoverList.get(document)?.has(element)
-  ) {
-    openInPopoverMode.set(element, 'hint');
   }
 
   previouslyFocusedElements.delete(element);
@@ -468,7 +455,7 @@ export function hideAllPopoversUntil(
     return closeAllOpenPopovers(document, focusPreviousElement, fireEvents);
   }
   if (hintPopoverList.get(document)?.has(endpoint as HTMLElement)) {
-    // run hide popover stack
+    // TODO: [hint] run hide popover stack
     return;
   }
   closeAllOpenPopoversInList(

--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -8,6 +8,7 @@ const HTMLDialogElement = globalThis.HTMLDialogElement || function () {};
 
 const topLayerElements = new WeakMap<Document, Set<HTMLElement>>();
 const autoPopoverList = new WeakMap<Document, Set<HTMLElement>>();
+// const hintPopoverList = new WeakMap<Document, Set<HTMLElement>>();
 export const visibilityState = new WeakMap<HTMLElement, 'hidden' | 'showing'>();
 function getPopoverVisibilityState(popover: HTMLElement): 'hidden' | 'showing' {
   return visibilityState.get(popover) || 'hidden';
@@ -39,12 +40,16 @@ export function popoverTargetAttributeActivationBehavior(
   }
 }
 
-// https://whatpr.org/html/8221/popover.html#check-popover-validity
+// https://html.spec.whatwg.org/#check-popover-validity
 function checkPopoverValidity(
   element: HTMLElement,
   expectedToBeShowing: boolean,
 ) {
-  if (element.popover !== 'auto' && element.popover !== 'manual') {
+  if (
+    element.popover !== 'auto' &&
+    element.popover !== 'manual' &&
+    element.popover !== 'hint'
+  ) {
     return false;
   }
   if (!element.isConnected) return false;
@@ -303,13 +308,12 @@ export function showPopover(element: HTMLElement) {
   queuePopoverToggleEventTask(element, 'closed', 'open');
 }
 
-// https://html.spec.whatwg.org/#hide-popover
+// https://html.spec.whatwg.org/#hide-popover-algorithm
 export function hidePopover(
   element: HTMLElement,
   focusPreviousElement = false,
   fireEvents = false,
 ) {
-  // https://whatpr.org/html/8221/popover.html#hide-popover
   if (!checkPopoverValidity(element, true)) {
     return;
   }

--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -474,7 +474,7 @@ function closeAllOpenPopoversInList(
 }
 
 // https://html.spec.whatwg.org/#hide-popover-stack-until
-function hidePopoverStackUntilUpdated(
+function hidePopoverStackUntil(
   endpoint: Element | Document,
   set: Set<HTMLElement>,
   focusPreviousElement: boolean,
@@ -498,7 +498,11 @@ function hidePopoverStackUntilUpdated(
     }
     if (!lastToHide) return;
     while (getPopoverVisibilityState(lastToHide) === 'showing' && set.size) {
-      hidePopover(lastToHide, focusPreviousElement, fireEvents);
+      hidePopover(
+        [...set].pop() as HTMLElement,
+        focusPreviousElement,
+        fireEvents,
+      );
     }
     if (set.has(endpoint as HTMLElement) && [...set].pop() !== endpoint) {
       repeatingHide = true;
@@ -520,7 +524,7 @@ export function hideAllPopoversUntil(
     return closeAllOpenPopovers(document, focusPreviousElement, fireEvents);
   }
   if (hintPopoverList.get(document)?.has(endpoint as HTMLElement)) {
-    hidePopoverStackUntilUpdated(
+    hidePopoverStackUntil(
       endpoint,
       hintPopoverList.get(document)!,
       focusPreviousElement,
@@ -538,7 +542,7 @@ export function hideAllPopoversUntil(
     return;
   }
 
-  hidePopoverStackUntilUpdated(
+  hidePopoverStackUntil(
     endpoint,
     autoPopoverList.get(document)!,
     focusPreviousElement,

--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -494,8 +494,8 @@ function hidePopoverStackUntil(
 ) {
   let repeatingHide = false;
   let hasRunOnce = false;
-  // TODO: This doesn't match the spec changes in
-  // https://github.com/whatwg/html/pull/9778/files#diff-41cf6794ba4200b839c53531555f0f3998df4cbb01a4d5cb0b94e3ca5e23947dR85830
+  // This deviates from the latest version of the spec, which has a bug:
+  // https://github.com/whatwg/html/issues/11007
   while (repeatingHide || !hasRunOnce) {
     hasRunOnce = true;
     let lastToHide = null;

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -176,6 +176,7 @@ export function apply() {
         if (!this.hasAttribute('popover')) return null;
         const value = (this.getAttribute('popover') || '').toLowerCase();
         if (value === '' || value == 'auto') return 'auto';
+        if (value == 'hint') return 'hint';
         return 'manual';
       },
       set(value) {

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -20,6 +20,13 @@ export function isSupported() {
   );
 }
 
+export function isHintSupported() {
+  const el = document.createElement('div');
+  el.setAttribute('popover', 'hint');
+  // `el.popover` is "manual" in non-supporting browsers
+  return el.popover === 'hint';
+}
+
 export function isPolyfilled() {
   // if the `showPopover` method is defined but is not "native code"
   // then we can infer it's been polyfilled

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -75,7 +75,7 @@ test('popover as "manual"', async ({ page }) => {
 });
 
 test('popover as "hint"', async ({ page }) => {
-  const popover = (await page.locator('#test-popover-invalid-hint')).nth(0);
+  const popover = (await page.locator('#hintPopover')).nth(0);
   await expect(popover).toBeFunctionalPopover();
 });
 

--- a/tests/hint.spec.ts
+++ b/tests/hint.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+function getSelectors(page) {
+  const section = page.locator('#popover-hint');
+  return {
+    section,
+    hintButton: section.getByRole('button', {
+      name: 'Hover to toggle Hint Popover 1',
+    }),
+    hintButton2: section.getByRole('button', {
+      name: 'Hover to toggle Hint Popover 2',
+    }),
+    autoButton: section.getByRole('button', { name: 'Show Auto Popover' }),
+  };
+}
+
+test('hints are light dismissed', async ({ page }) => {
+  const { hintButton, section } = getSelectors(page);
+  hintButton.hover();
+
+  const popover = page.locator('#hintPopover');
+  await expect(popover).toBeVisible();
+
+  section.click();
+  await expect(popover).toBeHidden();
+});
+
+test('opening hint closes other hint', async ({ page }) => {
+  const { hintButton, hintButton2 } = getSelectors(page);
+  hintButton.hover();
+
+  const popover = page.locator('#hintPopover');
+  await expect(popover).toBeVisible();
+
+  hintButton2.hover();
+  const popover2 = page.locator('#hintPopover2');
+  await expect(popover2).toBeVisible();
+  await expect(popover).toBeHidden();
+});
+
+test('opening hint does not close auto', async ({ page }) => {
+  const { hintButton, autoButton } = getSelectors(page);
+  autoButton.click();
+
+  const autoPopover = page.locator('#autoPopover');
+  await expect(autoPopover).toBeVisible();
+
+  hintButton.hover();
+  const hintPopover = page.locator('#hintPopover');
+  await expect(hintPopover).toBeVisible();
+  await expect(autoPopover).toBeVisible();
+});
+
+test('opening hint nested in auto closes other hints', async ({ page }) => {
+  const { hintButton, autoButton } = getSelectors(page);
+
+  autoButton.click();
+
+  const autoPopover = page.locator('#autoPopover');
+  await expect(autoPopover).toBeVisible();
+
+  hintButton.hover();
+  const hintPopover = page.locator('#hintPopover');
+  await expect(hintPopover).toBeVisible();
+
+  const nestedHintButton = page.getByRole('button', {
+    name: 'Hover to toggle Nested hint popover',
+  });
+  nestedHintButton.hover();
+
+  const nestedHintPopover = page.locator('#hintPopover3');
+  await expect(nestedHintPopover).toBeVisible();
+  await expect(hintPopover).toBeHidden();
+});
+
+test('opening hint does not close hint nested in auto', async ({ page }) => {
+  const { hintButton, autoButton } = getSelectors(page);
+
+  autoButton.click();
+
+  const autoPopover = page.locator('#autoPopover');
+  await expect(autoPopover).toBeVisible();
+
+  const nestedHintButton = page.getByRole('button', {
+    name: 'Hover to toggle Nested hint popover',
+  });
+  nestedHintButton.hover();
+
+  const nestedHintPopover = page.locator('#hintPopover3');
+  await expect(nestedHintPopover).toBeVisible();
+
+  hintButton.hover();
+  const hintPopover = page.locator('#hintPopover');
+  await expect(hintPopover).toBeVisible();
+  await expect(nestedHintPopover).toBeVisible();
+});
+
+test('closing hint does not close hint nested in auto', async ({ page }) => {
+  const { hintButton, hintButton2, autoButton } = getSelectors(page);
+
+  autoButton.click();
+
+  const autoPopover = page.locator('#autoPopover');
+  await expect(autoPopover).toBeVisible();
+
+  const nestedHintButton = page.getByRole('button', {
+    name: 'Hover to toggle Nested hint popover',
+  });
+  nestedHintButton.hover();
+
+  const nestedHintPopover = page.locator('#hintPopover3');
+  await expect(nestedHintPopover).toBeVisible();
+
+  // Show unrelated hint
+  hintButton.hover();
+  const hintPopover = page.locator('#hintPopover');
+  await expect(hintPopover).toBeVisible();
+  await expect(nestedHintPopover).toBeVisible();
+
+  // Show a different unrelated hint to hide the first one
+  hintButton2.hover();
+  await expect(hintPopover).toBeHidden();
+  await expect(nestedHintPopover).toBeVisible();
+});
+
+test('closing hint nested in auto closes unrelated hints', async ({ page }) => {
+  const { hintButton, autoButton } = getSelectors(page);
+
+  autoButton.click();
+
+  const autoPopover = page.locator('#autoPopover');
+  await expect(autoPopover).toBeVisible();
+
+  const nestedHintButton = page.getByRole('button', {
+    name: 'Hover to toggle Nested hint popover',
+  });
+  nestedHintButton.hover();
+
+  const nestedHintPopover = page.locator('#hintPopover3');
+  await expect(nestedHintPopover).toBeVisible();
+
+  // Show unrelated hint
+  hintButton.hover();
+  const hintPopover = page.locator('#hintPopover');
+  await expect(hintPopover).toBeVisible();
+  await expect(nestedHintPopover).toBeVisible();
+
+  // Hide nested hint
+  nestedHintButton.hover();
+  await expect(hintPopover).toBeHidden();
+  await expect(nestedHintPopover).toBeHidden();
+});
+
+test('closing auto hides nested hints', async ({ page }) => {
+  const { autoButton } = getSelectors(page);
+
+  autoButton.click();
+
+  const autoPopover = page.locator('#autoPopover');
+  await expect(autoPopover).toBeVisible();
+
+  const nestedHintButton = page.getByRole('button', {
+    name: 'Hover to toggle Nested hint popover',
+  });
+  nestedHintButton.hover();
+
+  const nestedHintPopover = page.locator('#hintPopover3');
+  await expect(nestedHintPopover).toBeVisible();
+
+  autoButton.click();
+  await expect(nestedHintPopover).toBeHidden();
+});


### PR DESCRIPTION
Fixes #227 

This adds support for `popover=hint`, but [as pointed out](https://github.com/oddbird/popover-polyfill/issues/227#issuecomment-2687441304), it would be great to selectively polyfill `hint` in browsers that don't support it but do have basic `popover` support. #242 tracks that specifically.

Relevant links:

- https://github.com/whatwg/html/pull/9778
- https://open-ui.org/components/popover-hint.research.explainer/#popoverhint-behavior
- https://developer.chrome.com/blog/popover-hint
- https://github.com/oddbird/popover-polyfill/pull/38