### PR TITLE
Return showing status from togglePopover

### DIFF
--- a/src/index-fn.ts
+++ b/src/index-fn.ts
@@ -21,9 +21,9 @@ declare global {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/showPopover) */
     showPopover(options?: PopoverShowPopoverOptions): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover) */
-    togglePopover(force?: boolean): void;
+    togglePopover(force?: boolean): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover) */
-    togglePopover(options?: PopoverTogglePopoverOptions): void;
+    togglePopover(options?: PopoverTogglePopoverOptions): boolean;
   }
 
   /* eslint-disable @typescript-eslint/no-empty-object-type */

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,9 +22,9 @@ declare global {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/showPopover) */
     showPopover(options?: PopoverShowPopoverOptions): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover) */
-    togglePopover(force?: boolean): void;
+    togglePopover(force?: boolean): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover) */
-    togglePopover(options?: PopoverTogglePopoverOptions): void;
+    togglePopover(options?: PopoverTogglePopoverOptions): boolean;
   }
 
   /* eslint-disable @typescript-eslint/no-empty-object-type */

--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -46,7 +46,7 @@ export function popoverTargetAttributeActivationBehavior(
 }
 
 // https://html.spec.whatwg.org/#check-popover-validity
-function checkPopoverValidity(
+export function checkPopoverValidity(
   element: HTMLElement,
   expectedToBeShowing: boolean,
 ) {

--- a/src/popover-helpers.ts
+++ b/src/popover-helpers.ts
@@ -46,7 +46,7 @@ export function popoverTargetAttributeActivationBehavior(
 }
 
 // https://html.spec.whatwg.org/#check-popover-validity
-export function checkPopoverValidity(
+function checkPopoverValidity(
   element: HTMLElement,
   expectedToBeShowing: boolean,
 ) {

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -1,6 +1,5 @@
 import { ToggleEvent } from './events.js';
 import {
-  checkPopoverValidity,
   getRootNode,
   hideAllPopoversUntil,
   hidePopover,
@@ -224,17 +223,19 @@ export function apply() {
         if (typeof options === 'boolean') {
           options = { force: options };
         }
+        // This differs from the spec, in that the `if` includes instances when
+        // popover is hidden and force=false. In that case, the spec only runs
+        // `check popover validity`. Because the polyfill doesn't throw errors
+        // in `check popover validity`, we pass this case to `hide popover`,
+        // which immediately checks popover validity and returns as a noop.
         if (
-          visibilityState.get(this) === 'showing' &&
-          (options.force === undefined || options.force === false)
+          (visibilityState.get(this) === 'showing' &&
+            options.force === undefined) ||
+          options.force === false
         ) {
           hidePopover(this, true, true);
         } else if (options.force === undefined || options.force === true) {
           showPopover(this);
-        } else {
-          // The popover is not showing, but force is `false`. This currently
-          // has no side effects, but is included for spec-completeness.
-          checkPopoverValidity(this, false);
         }
         return visibilityState.get(this) === 'showing';
       },

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -1,5 +1,6 @@
 import { ToggleEvent } from './events.js';
 import {
+  checkPopoverValidity,
   getRootNode,
   hideAllPopoversUntil,
   hidePopover,
@@ -219,19 +220,23 @@ export function apply() {
     togglePopover: {
       enumerable: true,
       configurable: true,
-      value(options: boolean | PopoverTogglePopoverOptions = {}) {
+      value(options: boolean | PopoverTogglePopoverOptions = {}): boolean {
         if (typeof options === 'boolean') {
           options = { force: options };
         }
         if (
-          (visibilityState.get(this) === 'showing' &&
-            options.force === undefined) ||
-          options.force === false
+          visibilityState.get(this) === 'showing' &&
+          (options.force === undefined || options.force === false)
         ) {
           hidePopover(this, true, true);
         } else if (options.force === undefined || options.force === true) {
           showPopover(this);
+        } else {
+          // The popover is not showing, but force is `false`. This currently
+          // has no side effects, but is included for spec-completeness.
+          checkPopoverValidity(this, false);
         }
+        return visibilityState.get(this) === 'showing';
       },
     },
   });

--- a/tests/methods.spec.ts
+++ b/tests/methods.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test('showPopover opens popover', async ({ page }) => {
+  const popover = (await page.locator('#manualPopover')).nth(0);
+  await expect(popover).toBeHidden();
+  await expect(
+    await popover.evaluate((node) => node.showPopover()),
+  ).toBeUndefined();
+  await expect(popover).toBeVisible();
+  // Does not throw an error if the popover is already open
+  await expect(
+    await popover.evaluate((node) => node.showPopover()),
+  ).toBeUndefined();
+  await expect(popover).toBeVisible();
+});
+
+test('hidePopover hides popover', async ({ page }) => {
+  // Arrange
+  const popover = (await page.locator('#manualPopover')).nth(0);
+  await expect(popover).toBeHidden();
+  await expect(
+    await popover.evaluate((node) => node.showPopover()),
+  ).toBeUndefined();
+  await expect(popover).toBeVisible();
+
+  // Act & Assert
+  await expect(
+    await popover.evaluate((node) => node.hidePopover()),
+  ).toBeUndefined();
+  await expect(popover).toBeHidden();
+  // Does not throw an error if the popover is already closed
+  await expect(
+    await popover.evaluate((node) => node.hidePopover()),
+  ).toBeUndefined();
+  await expect(popover).toBeHidden();
+});
+
+test('togglePopover, popover hidden, force undefined', async ({ page }) => {
+  // Arrange
+  const popover = (await page.locator('#manualPopover')).nth(0);
+  await expect(popover).toBeHidden();
+
+  // Act
+  await expect(await popover.evaluate((node) => node.togglePopover())).toBe(
+    true,
+  );
+  await expect(popover).toBeVisible();
+});
+
+test('togglePopover, popover hidden, force=true', async ({ page }) => {
+  // Arrange
+  const popover = (await page.locator('#manualPopover')).nth(0);
+  await expect(popover).toBeHidden();
+
+  // Act
+  await expect(
+    await popover.evaluate((node) => node.togglePopover({ force: true })),
+  ).toBe(true);
+  await expect(popover).toBeVisible();
+});
+
+test('togglePopover, popover hidden, force=false', async ({ page }) => {
+  // Arrange
+  const popover = (await page.locator('#manualPopover')).nth(0);
+  await expect(popover).toBeHidden();
+
+  // Act
+  await expect(
+    await popover.evaluate((node) => node.togglePopover({ force: false })),
+  ).toBe(false);
+  await expect(popover).toBeHidden();
+});
+
+test('togglePopover, popover shown, force undefined', async ({ page }) => {
+  // Arrange
+  const popover = (await page.locator('#manualPopover')).nth(0);
+  await expect(popover).toBeHidden();
+  await expect(
+    await popover.evaluate((node) => node.showPopover()),
+  ).toBeUndefined();
+  await expect(popover).toBeVisible();
+
+  // Act
+  await expect(await popover.evaluate((node) => node.togglePopover())).toBe(
+    false,
+  );
+  await expect(popover).toBeHidden();
+});
+
+test('togglePopover, popover shown, force=true', async ({ page }) => {
+  // Arrange
+  const popover = (await page.locator('#manualPopover')).nth(0);
+  await expect(popover).toBeHidden();
+  await expect(
+    await popover.evaluate((node) => node.showPopover()),
+  ).toBeUndefined();
+  await expect(popover).toBeVisible();
+
+  // Act
+  await expect(
+    await popover.evaluate((node) => node.togglePopover({ force: true })),
+  ).toBe(true);
+  await expect(popover).toBeVisible();
+});
+
+test('togglePopover, popover shown, force=false', async ({ page }) => {
+  // Arrange
+  const popover = (await page.locator('#manualPopover')).nth(0);
+  await expect(popover).toBeHidden();
+  await expect(
+    await popover.evaluate((node) => node.showPopover()),
+  ).toBeUndefined();
+  await expect(popover).toBeVisible();
+
+  // Act
+  await expect(
+    await popover.evaluate((node) => node.togglePopover({ force: false })),
+  ).toBe(false);
+  await expect(popover).toBeHidden();
+});


### PR DESCRIPTION
## Description
Returns showing state from `togglePopover`. 

This also documents the logic in cases where `force = false` and the popover is already hidden. 


## Related Issue(s)
Fixes #245 


## Steps to test/reproduce
Verify the 6 test cases in `test/methods.spec.ts` are as expected.