### PR TITLE
Document browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ This polyfills the HTML `popover` attribute and
 `showPopover`/`hidePopover`/`togglePopover` methods onto HTMLElement, as well as
 the `popovertarget` and `popovertargetaction` attributes on Button elements.
 
+## Browser Support
+
+- Firefox 88+ (includes Android)
+- Chrome 88+ (includes Android)
+- Edge 88+
+- Safari 14+ (includes iOS)
+
 ## Polyfill Installation
 
 ### Download a copy

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
       try {
         new CSSStyleSheet();
         window.supportsCSSStyleSheet = true;
-      } catch {
+      } catch (e) {
         // no support
       }
       document.querySelectorAll('[data-hover-target]').forEach((el) => {

--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
     "./dist/popover.iife.min.js"
   ],
   "scripts": {
-    "build:iife": "esbuild --bundle src/index.ts --outfile=dist/popover.iife.min.js --format=iife --minify --sourcemap",
-    "build:esm": "esbuild --bundle src/index.ts --outfile=dist/popover.js --format=esm --sourcemap",
-    "build:esm-min": "esbuild --bundle src/index.ts --outfile=dist/popover.min.js --format=esm --minify --sourcemap",
-    "build:esm-fn": "esbuild --bundle src/index-fn.ts --outfile=dist/popover-fn.js --format=esm --sourcemap",
-    "build:cjs-fn": "esbuild --bundle src/index-fn.ts --outfile=dist/popover-fn.cjs.js --format=cjs --sourcemap",
+    "build:iife": "esbuild --bundle src/index.ts --outfile=dist/popover.iife.min.js --format=iife --minify --sourcemap --target=chrome88,edge88,firefox88,safari14",
+    "build:esm": "esbuild --bundle src/index.ts --outfile=dist/popover.js --format=esm --sourcemap --target=chrome88,edge88,firefox88,safari14",
+    "build:esm-min": "esbuild --bundle src/index.ts --outfile=dist/popover.min.js --format=esm --minify --sourcemap --target=chrome88,edge88,firefox88,safari14",
+    "build:esm-fn": "esbuild --bundle src/index-fn.ts --outfile=dist/popover-fn.js --format=esm --sourcemap --target=chrome88,edge88,firefox88,safari14",
+    "build:cjs-fn": "esbuild --bundle src/index-fn.ts --outfile=dist/popover-fn.cjs.js --format=cjs --sourcemap --target=chrome88,edge88,firefox88,safari14",
     "clean": "rm -rf dist",
     "build": "run-s clean build:* types",
     "server:start": "esbuild --bundle src/index.ts --format=esm --servedir=. --outdir=dist --sourcemap --serve=\"${PORT:-3000}\" --log-level=\"${LEVEL:-info}\"",


### PR DESCRIPTION
Closes #15 

The JS support could go back much further, but the current CSS is limited by `:where` and `:not` support. Manual testing seemed to reveal a bug in Firefox v84-87 with `height: -moz-fit-content`, so I limited it to FF88+.