### PR TITLE
Respect `defaultPrevented` in `popovertarget` click handler

### DIFF
--- a/src/popover.ts
+++ b/src/popover.ts
@@ -351,7 +351,9 @@ export function apply() {
   applyPopoverInvokerElementMixin(HTMLInputElement);
 
   const handleInvokerActivation = (event: Event) => {
-    // Composed path allows us to find the target within shadowroots
+    if (event.defaultPrevented) {
+      return;
+    }
     const composedPath = event.composedPath() as HTMLElement[];
     const target = composedPath[0];
     if (!(target instanceof Element) || target?.shadowRoot) {

--- a/tests/triggers.spec.ts
+++ b/tests/triggers.spec.ts
@@ -259,3 +259,24 @@ test('clicking #shadowInInvoker should show then hide popover', async ({
   await page.click('#shadowInvokedHost');
   await expect(popover).toBeHidden();
 });
+
+test('clicking button[popovertarget=defaultPopover] should not trigger popover when defaultPrevented is true', async ({
+  page,
+}) => {
+  const popover = (await page.locator('#defaultPopover')).nth(0);
+  await expect(popover).toBeHidden();
+  await page.evaluate(() => {
+    const button = document.querySelector(
+      'button[popovertarget="defaultPopover"]',
+    );
+    button?.addEventListener(
+      'click',
+      (event) => {
+        event.preventDefault();
+      },
+      { capture: true },
+    );
+  });
+  await page.click('button[popovertarget=defaultPopover]');
+  await expect(popover).toBeHidden();
+});


### PR DESCRIPTION
Prevent `popovertarget` invokers from processing clicks when `event.defaultPrevented` is true. This makes the polyfill behave closer to the native `popovertarget` implementation where calling `event.preventDefault()` _will_ make the `popovertargetaction` not trigger.

## Test plan

Added a new e2e test to ensure this works as expected.