### PR TITLE
Document :where selector option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,11 @@ some caveats which will need accommodations:
     results in an invalid selector, and so the entire declaration is thrown
     away. This is important because if you intend to style a popover using
     `.\:popover-open` it will need to be a separate declaration. For example,
-    `[popover]:popover-open, [popover].\:popover-open` will not work.
+    `[popover]:popover-open, [popover].\:popover-open` will not work. If your
+    browser support requirements allow you to use
+    [`:where()`](https://web-platform-dx.github.io/web-features-explorer/features/where/),
+    you can use `[popover]:where(:popover-open, .\:popover-open)` to target the
+    native and polyfilled selectors.
 
 - Native `popover` elements use the `:top-layer` pseudo element which gets
   placed above all other elements on the page, regardless of overflow or


### PR DESCRIPTION
![](https://picsum.photos/600/400)

## Description

:where is a reasonable solution for selecting both polyfilled and native `:popover-open`, and there's sufficient time gap between support for where and popover that it makes sense to note here. 

## Steps to test/reproduce
Open this pen- 
https://codepen.io/jamessw/pen/dPpxZEa